### PR TITLE
Feature/content json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Fixed requests sometimes failing due to the body encoding (now forces JSONEncoding, instead of using the default setting of `Alamofire`).
+
 ## 3.6.0 - Released 28 Jul 2022
 
 - Added new SSL certificate of [parley.nu](https://parley.nu) for SSL pinning.

--- a/Source/Data/Remotes/ParleyRemote.swift
+++ b/Source/Data/Remotes/ParleyRemote.swift
@@ -59,7 +59,7 @@ internal class ParleyRemote {
     @discardableResult internal static func execute<T: BaseMappable>(_ method: HTTPMethod, _ path: String, parameters: Parameters? = nil, keyPath: String? = "data", onSuccess: @escaping (_ items: [T])->(), onFailure: @escaping (_ error: Error)->()) -> DataRequest {
         debugPrint("ParleyRemote.execute:: \(method) \(getUrl(path)) \(parameters ?? [:])")
         
-                let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
+        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
         request.validate(statusCode: 200...299).responseArray(keyPath: keyPath) { (response: AFDataResponse<[T]>) in
             switch response.result {
             case .success(let items):

--- a/Source/Data/Remotes/ParleyRemote.swift
+++ b/Source/Data/Remotes/ParleyRemote.swift
@@ -59,7 +59,7 @@ internal class ParleyRemote {
     @discardableResult internal static func execute<T: BaseMappable>(_ method: HTTPMethod, _ path: String, parameters: Parameters? = nil, keyPath: String? = "data", onSuccess: @escaping (_ items: [T])->(), onFailure: @escaping (_ error: Error)->()) -> DataRequest {
         debugPrint("ParleyRemote.execute:: \(method) \(getUrl(path)) \(parameters ?? [:])")
         
-        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, headers: getHeaders())
+                let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
         request.validate(statusCode: 200...299).responseArray(keyPath: keyPath) { (response: AFDataResponse<[T]>) in
             switch response.result {
             case .success(let items):
@@ -75,7 +75,7 @@ internal class ParleyRemote {
     @discardableResult internal static func execute<T: BaseMappable>(_ method: HTTPMethod, _ path: String, parameters: Parameters?=nil, keyPath: String? = "data", onSuccess: @escaping (_ item: T) -> (), onFailure: @escaping (_ error: Error) -> ()) -> DataRequest {
         debugPrint("ParleyRemote.execute:: \(method) \(getUrl(path)) \(parameters ?? [:])")
         
-        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, headers: getHeaders())
+        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
         request.validate(statusCode: 200...299).responseObject(keyPath: keyPath) { (response: AFDataResponse<T>) in
             switch response.result {
             case .success(let item):
@@ -91,7 +91,7 @@ internal class ParleyRemote {
     @discardableResult internal static func execute(_ method: HTTPMethod, _ path: String, parameters: Parameters?=nil, onSuccess: @escaping ()->(), onFailure: @escaping (_ error: Error)->()) -> DataRequest {
         debugPrint("ParleyRemote.execute:: \(method) \(getUrl(path)) \(parameters ?? [:])")
         
-        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, headers: getHeaders())
+        let request = sessionManager.request(getUrl(path), method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
         request.validate(statusCode: 200...299).responseJSON { (response) in
             switch response.result {
             case .success:
@@ -132,7 +132,7 @@ internal class ParleyRemote {
         } else {
             debugPrint("ParleyRemote.execute:: \(method) \(getUrl(path)) \(parameters ?? [:])")
             
-            let request = sessionManager.request(url, method: method, parameters: parameters, headers: getHeaders())
+            let request = sessionManager.request(url, method: method, parameters: parameters, encoding: JSONEncoding.default, headers: getHeaders())
             request.validate(statusCode: 200...299).responseImage { response in
                 switch response.result {
                 case .success(let image):


### PR DESCRIPTION
Previously the  body was encoded using `Alamofire`'s default setting: `URLEncoding.default`. Now forcing JSONEncoding as body. Resolves the issue where Alamofire internally puts the body URLEncoded instead of json. Also fixes the content-type header to be consistent.

Fixes #32 