### PR TITLE
Use swift package test target for tests in the project

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,12 +31,13 @@ let package = Package(
                 "Reachability",
                 "MarkdownKit"
             ],
-            path: "Source",
-            exclude: [
-                "ParleyTests/Data/ParleyInMemoryDataSource.swift",
-                "ParleyTests/MessagesManagerTests.swift",
-            ]
-        )
+            path: "Source"
+        ),
+        .testTarget(
+            name: "ParleyTests",
+            dependencies: ["Parley"],
+            path: "Tests"
+        ),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Tests/Data/ParleyInMemoryDataSource.swift
+++ b/Tests/Data/ParleyInMemoryDataSource.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Parley
+@testable import Parley
 
 class ParleyInMemoryDataSource {
 

--- a/Tests/MessagesManagerTests.swift
+++ b/Tests/MessagesManagerTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Parley
 
-final internal class MessagesManagerTests: XCTestCase {
+final class MessagesManagerTests: XCTestCase {
     
     struct MessagesManagerTestsError: Error {
         let message: String


### PR DESCRIPTION
In the Sources of the project there was a folder containing tests. This folder was excluded in the sources target. This way you was not able to run the test easily within Xcode when opening the project as a swift package. This pr does move those tests to a separate folder and creates a test target in the package.swift file now you are able to run them through Xcode.

<img width="264" alt="Screenshot 2023-12-22 at 11 04 47" src="https://github.com/parley-messaging/ios-library/assets/6486389/5afa7128-d909-4c9b-8629-a1bf4bb226c9">
