### PR TITLE
Formatted error message from Parley when an error occurs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+- Parley now returns the formatted error message of the backend when an error occurs when configuring or registering the device.
+
 ## 3.9.0 - Released 17 Jan 2024
 
 - Parley now uses codables for mapping the models (instead of ObjectMapper). This change is backwards compatible. Existing chats remain unaffected and will continue to work.

--- a/Example/ParleyExample/Supporting Files/en.lproj/Localizable.strings
+++ b/Example/ParleyExample/Supporting Files/en.lproj/Localizable.strings
@@ -4,8 +4,10 @@
 "identifier_customer_identification_placeholder" = "Customer identification (optional)";
 "identifier_start" = "Start chat";
 
-"identifier_error_title" = "Incorrect identification code";
-"identifier_error_body" = "You have entered an incorrect identification code. Try again.";
+"identifier_error_invalid_title" = "Incorrect identification code";
+"identifier_error_invalid_body" = "You have entered an incorrect identification code. Try again.";
+"identifier_error_start_title" = "An error has occurred";
+"identifier_error_start_body" = "The chat cannot be started, due to the following reason: %@ (%@)";
 
 "general_ok" = "Ok";
 

--- a/Example/ParleyExample/Supporting Files/nl.lproj/Localizable.strings
+++ b/Example/ParleyExample/Supporting Files/nl.lproj/Localizable.strings
@@ -4,8 +4,10 @@
 "identifier_customer_identification_placeholder" = "Klant identificatie (optioneel)";
 "identifier_start" = "Chat starten";
 
-"identifier_error_title" = "Foutieve identificatie code";
-"identifier_error_body" = "Je hebt een foutieve identificatie code ingevoerd. Probeer opnieuw.";
+"identifier_error_invalid_title" = "Foutieve identificatie code";
+"identifier_error_invalid_body" = "Je hebt een foutieve identificatie code ingevoerd. Probeer opnieuw.";
+"identifier_error_start_title" = "Er is een fout opgetreden";
+"identifier_error_start_body" = "De chat kan niet worden gestart, door de volgende reden: %@ (%@).";
 
 "general_ok" = "Oke";
 

--- a/Sources/Parley/Extensions/ErrorExtension.swift
+++ b/Sources/Parley/Extensions/ErrorExtension.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Error {
+    
+    func getFormattedMessage() -> String {
+        guard let parleyResponse = self as? ParleyErrorResponse,
+              let parleyMessage = parleyResponse.notifications.first?.message else {
+            return self.localizedDescription
+        }
+        return parleyMessage
+    }
+}

--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -169,7 +169,7 @@ public class Parley {
             } else {
                 self.state = .failed
 
-                onFailure?((error as NSError).code, (error as NSError).localizedDescription)
+                onFailure?((error as NSError).code, error.getFormattedMessage())
             }
         }
 
@@ -244,7 +244,7 @@ public class Parley {
             DeviceRepository().register({ _ in
                 onSuccess?()
             }) { error in
-                onFailure?((error as NSError).code, (error as NSError).localizedDescription)
+                onFailure?((error as NSError).code, error.getFormattedMessage())
             }
         }
     }


### PR DESCRIPTION
- Retrieves the error message from the Parley response when one occurs
- Returns the formatted message as error, instead of a localised one based on the error class
- Displays error message in the demo app as an alert in case offline messaging is disabled