### PR TITLE
Correct seperation of `ParleyNetworkSession`

### DIFF
--- a/Example/ParleyExample/Extension/UIButtonExtension.swift
+++ b/Example/ParleyExample/Extension/UIButtonExtension.swift
@@ -1,23 +1,23 @@
 import UIKit
 
 extension UIButton {
-    
+
     func setLoading(_ loading: Bool) {
         DispatchQueue.main.async {
             let tag = 808404 // The tag of a UIActivityIndicatorView
             if loading {
                 self.isEnabled = false
                 self.alpha = 0.5
-                
+
                 let buttonHeight = self.bounds.size.height
                 let buttonWidth = self.bounds.size.width
-                
+
                 let activityIndicatorView = UIActivityIndicatorView()
                 activityIndicatorView.center = CGPoint(x: buttonWidth / 2, y: buttonHeight / 2)
                 activityIndicatorView.tag = tag
                 activityIndicatorView.color = UIColor.white
                 activityIndicatorView.startAnimating()
-                
+
                 self.addSubview(activityIndicatorView)
             } else {
                 self.isEnabled = true

--- a/Sources/Parley/ApiVersion.swift
+++ b/Sources/Parley/ApiVersion.swift
@@ -3,6 +3,6 @@ import Foundation
 public enum ApiVersion {
 
     case v1_6
-  
+
     case v1_7
 }

--- a/Sources/Parley/Data/ImageLoader.swift
+++ b/Sources/Parley/Data/ImageLoader.swift
@@ -62,7 +62,7 @@ private extension ImageLoader {
             }
             return image
         }
-        
+
         requests[id] = request
         return request
     }

--- a/Sources/Parley/Data/Local/Encrypted/ParleyCrypter.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyCrypter.swift
@@ -1,26 +1,26 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 public class ParleyCrypter {
-    
+
     enum ParleyCrypterError: Error {
         case failedToEncrypt
     }
-    
+
     private let key: SymmetricKey
-    
+
     public init(key: String, size: SymmetricKeySize = .bits128) throws {
         self.key = try SymmetricKey(key: key, size: size)
     }
-    
+
     func encrypt(_ data: Data) throws -> Data {
         guard let encrypted = try AES.GCM.seal(data, using: key).combined else {
             throw ParleyCrypterError.failedToEncrypt
         }
-        
+
         return encrypted
     }
-    
+
     func decrypt(_ data: Data) throws -> Data {
         let sealedBox = try AES.GCM.SealedBox(combined: data)
         return try AES.GCM.open(sealedBox, using: key)

--- a/Sources/Parley/Data/Local/Encrypted/ParleyEcryptedStore.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyEcryptedStore.swift
@@ -42,7 +42,8 @@ extension ParleyEncryptedStore {
             return nil
         }
     }
-    
+
+    @discardableResult
     public func set(_ string: String, forKey key: String) -> Bool {
         guard let data = string.data(using: .utf8) else { return false }
         return set(data, forKey: key)

--- a/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedImageDataSource.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedImageDataSource.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public class ParleyEncryptedImageDataSource {
-    
+
     private let store: ParleyEncryptedStore
-    
+
     public enum Directory {
         case `default`
         case custom(String)
-        
+
         var path: String {
             switch self {
             case .default:
@@ -32,7 +32,7 @@ public class ParleyEncryptedImageDataSource {
 }
 
 extension ParleyEncryptedImageDataSource: ParleyImageDataSource {
-    
+
     public func clear() -> Bool {
         do {
             for url in getFiles() {

--- a/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedKeyValueDataSource.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedKeyValueDataSource.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public class ParleyEncryptedKeyValueDataSource {
-    
+
     private let store: ParleyEncryptedStore
-    
+
     public enum Directory {
         case `default`
         case custom(String)
-        
+
         var path: String {
             switch self {
             case .default:
@@ -32,30 +32,30 @@ public class ParleyEncryptedKeyValueDataSource {
 }
 
 extension ParleyEncryptedKeyValueDataSource: ParleyKeyValueDataSource {
-    
+
     @discardableResult
     public func clear() -> Bool {
         store.clear()
     }
-    
+
     public func string(forKey key: String) -> String? {
         store.string(forKey: key)
     }
-    
+
     public func data(forKey key: String) -> Data? {
         store.data(forKey: key)
     }
-    
+
     @discardableResult
     public func set(_ string: String, forKey key: String) -> Bool {
         store.set(string, forKey: key)
     }
-    
+
     @discardableResult
     public func set(_ data: Data, forKey key: String) -> Bool {
         store.set(data, forKey: key)
     }
-    
+
     @discardableResult
     public func removeObject(forKey key: String) -> Bool {
         store.removeObject(forKey: key)

--- a/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedMessageDataSource.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedMessageDataSource.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public class ParleyEncryptedMessageDataSource {
-    
+
     private let store: ParleyEncryptedStore
-    
+
     public enum Directory {
         case `default`
         case custom(String)
-        
+
         var path: String {
             switch self {
             case .default:
@@ -32,16 +32,16 @@ public class ParleyEncryptedMessageDataSource {
 }
 
 extension ParleyEncryptedMessageDataSource: ParleyMessageDataSource {
-    
+
     public func clear() -> Bool {
         store.clear()
     }
-    
+
     public func all() -> [Message]? {
         guard let jsonData = store.data(forKey: kParleyCacheKeyMessages) else { return nil }
         return try? CodableHelper.shared.decode([Message].self, from: jsonData)
     }
-    
+
     public func save(_ messages: [Message]) {
         if let messages = try? CodableHelper.shared.toJSONString(messages) {
             store.set(messages, forKey: kParleyCacheKeyMessages)

--- a/Sources/Parley/Data/Local/ParleyDataSource.swift
+++ b/Sources/Parley/Data/Local/ParleyDataSource.swift
@@ -1,5 +1,5 @@
 public protocol ParleyDataSource: AnyObject {
-    
-    @discardableResult 
+
+    @discardableResult
     func clear() -> Bool
 }

--- a/Sources/Parley/Data/Local/ParleyImageDataSource.swift
+++ b/Sources/Parley/Data/Local/ParleyImageDataSource.swift
@@ -3,12 +3,13 @@ import Foundation
 public protocol ParleyImageDataSource: AnyObject, ParleyDataSource {
 
     func all() -> [ParleyStoredImage]
-    
+
     func image(id: ParleyStoredImage.ID) -> ParleyStoredImage?
 
     func save(images: [ParleyStoredImage])
 
     func save(image: ParleyStoredImage)
-    
+
+    @discardableResult
     func delete(id: ParleyStoredImage.ID) -> Bool
 }

--- a/Sources/Parley/Data/Local/ParleyKeyValueDataSource.swift
+++ b/Sources/Parley/Data/Local/ParleyKeyValueDataSource.swift
@@ -7,7 +7,7 @@ public protocol ParleyKeyValueDataSource: AnyObject, ParleyDataSource {
 
     @discardableResult
     func set(_ string: String, forKey key: String) -> Bool
-    
+
     @discardableResult
     func set(_ data: Data, forKey key: String) -> Bool
 

--- a/Sources/Parley/Data/Models/Common/HTTPHeaders.swift
+++ b/Sources/Parley/Data/Models/Common/HTTPHeaders.swift
@@ -2,4 +2,6 @@ import Foundation
 
 enum HTTPHeaders: String {
     case contentType = "Content-Type"
+    case authorization = "Authorization"
+    case xIrisIdentification = "x-iris-identification"
 }

--- a/Sources/Parley/Data/Models/Common/ParleyHTTPErrorResponse.swift
+++ b/Sources/Parley/Data/Models/Common/ParleyHTTPErrorResponse.swift
@@ -5,7 +5,7 @@ public struct ParleyHTTPErrorResponse: Error {
     public let headers: [String: String]?
     public let data: Data?
     public let error: Error
-    
+
     public init(
         statusCode: Int? = nil,
         headers: [String : String]? = nil,
@@ -17,7 +17,7 @@ public struct ParleyHTTPErrorResponse: Error {
         self.data = data
         self.error = error
     }
-    
+
     var isOfflineError: Bool {
         statusCode == nil && headers == nil && data == nil
     }

--- a/Sources/Parley/Data/Models/Helpers/CodableHelper.swift
+++ b/Sources/Parley/Data/Models/Helpers/CodableHelper.swift
@@ -18,20 +18,6 @@ struct CodableHelper {
         return result
     }
 
-    /// Converting object to post-able dictionary
-    func toDictionary<T>(_ value: T) throws -> [String: Any] where T: Encodable {
-        let data = try encoder.encode(value)
-        let object = try JSONSerialization.jsonObject(with: data)
-        guard let json = object as? [String: Any] else {
-            let context = DecodingError.Context(
-                codingPath: [],
-                debugDescription: "Deserialized object is not a dictionary"
-            )
-            throw DecodingError.typeMismatch(type(of: object), context)
-        }
-        return json
-    }
-
     func encode<T>(_ value: T) throws -> Data where T: Encodable {
         try encoder.encode(value)
     }

--- a/Sources/Parley/Data/Models/Message.swift
+++ b/Sources/Parley/Data/Models/Message.swift
@@ -49,13 +49,13 @@ public final class Message: Codable, Equatable {
     var title: String?
     var message: String?
     var responseInfoType: String?
-    
+
     var media: MediaObject?
-   
+
     var hasMedium: Bool {
         media != nil
     }
-    
+
     var hasButtons: Bool {
         guard let buttons else { return false }
         return !buttons.isEmpty
@@ -134,7 +134,7 @@ public final class Message: Codable, Equatable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(id, forKey: .id)
         try container.encodeIfPresent(uuid, forKey: .uuid)
         if let time {
             try container.encode(Int(time.timeIntervalSince1970), forKey: .time)

--- a/Sources/Parley/Data/Models/ParleyErrorResponse/NotificationErrors/MediaUploadNotificationErrorKind.swift
+++ b/Sources/Parley/Data/Models/ParleyErrorResponse/NotificationErrors/MediaUploadNotificationErrorKind.swift
@@ -5,9 +5,9 @@ enum MediaUploadNotificationErrorKind: String, Error, CaseIterable, Codable {
     case missingMedia = "missing_media"
     case mediaTooLarge = "media_too_large"
     case couldNotSaveMedia = "could_not_save_media"
-    
+
     var message: String { rawValue }
-    
+
     var formattedMessage: String {
         switch self {
         case .invalidMediaType, .missingMedia, .couldNotSaveMedia:

--- a/Sources/Parley/Data/Models/ParleyErrorResponse/ParleyErrorResponse.swift
+++ b/Sources/Parley/Data/Models/ParleyErrorResponse/ParleyErrorResponse.swift
@@ -1,17 +1,21 @@
 import Foundation
 
 struct ParleyErrorResponse: Error, Codable {
-    let status: String
+    enum Status: String, Codable {
+        case success = "SUCCESS"
+        case error = "ERROR"
+    }
+    
+    let status: Status
     let notifications: [Notification]
     let metadata: Metadata?
-    
+
     struct Notification: Codable {
         let type: String
         let message: String
     }
-    
+
     struct Metadata: Codable {
-//        let values: [String: Any]
         let method: String
         let duration: Double
     }

--- a/Sources/Parley/Data/Models/ParleyStoredImage.swift
+++ b/Sources/Parley/Data/Models/ParleyStoredImage.swift
@@ -23,24 +23,24 @@ public struct ParleyStoredImage: Codable {
             type: media.type
         )
     }
-    
+
     struct FilePath: Codable, CustomStringConvertible {
         let name: String
         let type: ParleyImageType
-        
+
         var description: String {
             [name, type.fileExtension].joined().replacingOccurrences(of: "/", with: "_")
         }
-        
+
         package init(name: String, type: ParleyImageType) {
             self.name = name
             self.type = type
         }
-        
+
         static func create(image: ParleyStoredImage) -> String {
             FilePath(name: image.filename, type: image.type).description
         }
-        
+
         static func create(path: String) -> FilePath? {
             if let url = URL(string: path) {
                 return Self.decode(url: url)
@@ -48,14 +48,14 @@ public struct ParleyStoredImage: Codable {
                 return nil
             }
         }
-        
+
         static func decode(url: URL) -> FilePath? {
             var splitFilename = url.lastPathComponent.split(separator: ".")
             guard splitFilename.count >= 2 else { return nil }
-            
+
             let type = String(splitFilename.removeLast())
             let fileName = String(splitFilename.removeLast())
-            
+
             guard let imageType = ParleyImageType(rawValue: type) else { return nil }
             return FilePath(name: fileName, type: imageType)
         }
@@ -63,7 +63,7 @@ public struct ParleyStoredImage: Codable {
 }
 
 extension ParleyStoredImage: Identifiable {
-    
+
     public var id: String { filename }
 }
 

--- a/Sources/Parley/Data/Models/RemoteImage.swift
+++ b/Sources/Parley/Data/Models/RemoteImage.swift
@@ -3,7 +3,7 @@ import Foundation
 struct RemoteImage: Identifiable {
     let id: String
     let type: ParleyImageType
-    
+
     init(id: String, type: ParleyImageType) {
         self.id = id
         self.type = type

--- a/Sources/Parley/Data/Remotes/DeviceRemoteService.swift
+++ b/Sources/Parley/Data/Remotes/DeviceRemoteService.swift
@@ -16,7 +16,7 @@ final class DeviceRemoteService {
         remote.execute(
             .post,
             path: "devices",
-            parameters: try? CodableHelper.shared.toDictionary(device),
+            body: device,
             onSuccess: onSuccess,
             onFailure: onFailure
         )

--- a/Sources/Parley/Data/Remotes/MessageRemoteService.swift
+++ b/Sources/Parley/Data/Remotes/MessageRemoteService.swift
@@ -22,6 +22,7 @@ final class MessageRemoteService {
         remote.execute(.get, path: "messages", keyPath: nil, onSuccess: onSuccess, onFailure: onFailure)
     }
 
+    @discardableResult
     func findBefore(
         _ id: Int,
         onSuccess: @escaping (_ messageCollection: MessageCollection) -> (),
@@ -56,10 +57,11 @@ final class MessageRemoteService {
         onFailure: @escaping (_ error: Error) -> ()
     ) {
         DispatchQueue.global().async { [weak self] in
-            self?.remote.execute(
+            guard let self else { return }
+            remote.execute(
                 .post,
                 path: "messages",
-                parameters: try? self?.codableHelper.toDictionary(message),
+                body: message,
                 onSuccess: { (savedMessage: Message) in
                     message.id = savedMessage.id
                     onSuccess(message)
@@ -84,7 +86,7 @@ final class MessageRemoteService {
             result: completion
         )
     }
-    
+
     internal func findMedia(_ id: String, result: @escaping (Result<ParleyImageNetworkModel, Error>) -> Void) {
         remote.execute(.get, path: "media/\(id)", result: result)
     }

--- a/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
+++ b/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
@@ -6,7 +6,7 @@ import UIKit
 /// > Warning: By implementing this protocol you are responsible for SSL pinning
 /// and other security related features that `Alamofire` will
 /// provide out of the box.
-/// 
+///
 /// By default the Parley SDK does use the `Alamofire` library to make
 /// network requests. You can also use your own network layer. To do
 /// so implement this protocol and register this with the following code:
@@ -22,8 +22,8 @@ public protocol ParleyNetworkSession {
     @discardableResult
     func request(
         _ url: URL,
+        data: Data?,
         method: ParleyHTTPRequestMethod,
-        parameters: [String: Any]?,
         headers: [String: String],
         completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
     ) -> ParleyRequestCancelable

--- a/Sources/Parley/Data/Repositories/ImageRepository.swift
+++ b/Sources/Parley/Data/Repositories/ImageRepository.swift
@@ -31,18 +31,18 @@ extension ImageRepository {
             return dataSource?.image(id: filePath.description)
         }
     }
-    
+
     func getRemoteImage(for imageId: RemoteImage.ID) async throws -> ParleyImageNetworkModel {
         let mediaURL = try createMediaURL(path: imageId)
         let networkImage = try await fetchMedia(url: mediaURL)
-        
+
         await MainActor.run {
             store(networkImage: networkImage, remotePath: imageId)
         }
-        
+
         return networkImage
     }
-    
+
     func upload(image storedImage: ParleyStoredImage) async throws -> RemoteImage {
         return try await withCheckedThrowingContinuation { continuation in
             messageRemoteService.upload(
@@ -54,9 +54,9 @@ extension ImageRepository {
                 do {
                     let mediaResponse = try imageResult.get()
                     let remoteImage = RemoteImage(id: mediaResponse.media, type: storedImage.type)
-                    
+
                     move(storedImage, to: remoteImage.id)
-                    
+
                     continuation.resume(returning: remoteImage)
                 } catch {
                     continuation.resume(throwing: error)

--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -295,7 +295,7 @@ public final class Parley {
     }
     
     private func clearMessagesAndDataSources() {
-        messagesManager.clear()
+        messagesManager?.clear()
         messageDataSource?.clear()
         keyValueDataSource?.clear()
         delegate?.didReceiveMessages()
@@ -304,7 +304,7 @@ public final class Parley {
     // MARK: Devices
     private func registerDevice(onSuccess: (() -> ())? = nil, onFailure: ((_ code: Int, _ message: String) -> ())? = nil) {
         if self.state == .configuring || self.state == .configured {
-            deviceRepository.register(device: makeDeviceData(), onSuccess: { _ in
+            deviceRepository?.register(device: makeDeviceData(), onSuccess: { _ in
                 onSuccess?()
             }, onFailure: { error in
                 onFailure?((error as NSError).code, error.getFormattedMessage())
@@ -357,13 +357,13 @@ public final class Parley {
     
     private func sendPendingMessage(message: Message) async {
         do {
-            let messages = try await ensureMediaUploadedIfAvailable(message)
-            await send(message, isNewMessage: false)
+            let updatedMessage = try await ensureMediaUploadedIfAvailable(message)
+            await send(updatedMessage, isNewMessage: false)
         } catch {
             await failedToSend(message: message, error: error)
         }
     }
-    
+
     private func ensureMediaUploadedIfAvailable(_ message: Message) async throws -> Message {
         guard let storedImage = getStoredMedia(for: message) else { return message }
         return try await upload(storedImage: storedImage, message: message)
@@ -776,14 +776,14 @@ extension Parley {
      */
     public static func reset(onSuccess: (() -> ())? = nil, onFailure: ((_ code: Int, _ message: String) -> ())? = nil) {
         Task {
-            await shared.imageLoader.reset()
+            await shared.imageLoader?.reset()
         }
         
         shared.userAuthorization = nil
         shared.userAdditionalInformation = nil
-        shared.imageRepository.reset()
-        
-        Parley.shared.registerDevice(onSuccess: {
+        shared.imageRepository?.reset()
+
+        shared.registerDevice(onSuccess: {
             shared.secret = nil
             onSuccess?()
         }, onFailure: { code, message in

--- a/Sources/ParleyNetwork/Alamofire.HTTPMethod+Mapper.swift
+++ b/Sources/ParleyNetwork/Alamofire.HTTPMethod+Mapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Alamofire
+import Foundation
 import enum Parley.ParleyHTTPRequestMethod
 
 extension Alamofire.HTTPMethod {

--- a/Tests/ParleyNetworkTests/Alamofire.HTTPMethodTests.swift
+++ b/Tests/ParleyNetworkTests/Alamofire.HTTPMethodTests.swift
@@ -1,9 +1,9 @@
+import Alamofire
 import Foundation
 import Parley
-import XCTest
-import Alamofire
-@testable import ParleyNetwork
 import enum Parley.ParleyHTTPRequestMethod
+import XCTest
+@testable import ParleyNetwork
 
 final class AlamofireHTTPMethodTests: XCTestCase {
     func testMappings() {

--- a/Tests/ParleyNetworkTests/Parley+configureTests.swift
+++ b/Tests/ParleyNetworkTests/Parley+configureTests.swift
@@ -25,7 +25,7 @@ final class AlamofireHTTParleyConfigureTestsPMethodTests: XCTestCase {
             networkConfig: ParleyNetworkConfig(
                 url: url,
                 path: path,
-                apiVersion: .v1_6, 
+                apiVersion: .v1_7,
                 headers: headers
             )
         )

--- a/Tests/ParleyTests/Data/Models/Common/ResponseValidatorTests.swift
+++ b/Tests/ParleyTests/Data/Models/Common/ResponseValidatorTests.swift
@@ -3,16 +3,16 @@ import XCTest
 @testable import Parley
 
 final class ResponseValidatorTests: XCTestCase {
-    
+
     private struct ExampleValidator: ResponseValidator {
         let statusCode: Int
     }
-    
+
     func testSuccessValidation() {
         let sut = ExampleValidator(statusCode: 200)
         XCTAssertNoThrow(try sut.validate(statusCode: 200...202))
     }
-    
+
     func testErrorValidation() {
         let sut = ExampleValidator(statusCode: 200)
         XCTAssertThrowsError(try sut.validate(statusCode: 300...399)) { error in

--- a/Tests/ParleyTests/Data/Models/Helpers/CodableHelperTests.swift
+++ b/Tests/ParleyTests/Data/Models/Helpers/CodableHelperTests.swift
@@ -23,13 +23,6 @@ final class CodableHelperTests: XCTestCase {
         XCTAssertEqual(result, "{\"tasks\":[\"1\",\"2\"]}")
     }
 
-    func testToDictionary() throws {
-        let result = try sut.toDictionary(CodableObject(tasks: ["1", "2"]))
-
-        XCTAssertEqual(result.first?.key, "tasks")
-        XCTAssertNotNil(result.first?.value)
-    }
-
     func testEncodeDecode() throws {
         let object = CodableObject(tasks: ["1", "2"])
         let encoded = try sut.encode(object)

--- a/Tests/ParleyTests/Data/Remotes/ParleyRemoteTests.swift
+++ b/Tests/ParleyTests/Data/Remotes/ParleyRemoteTests.swift
@@ -13,14 +13,14 @@ final class ParleyRemoteTests: XCTestCase {
 
     override func setUpWithError() throws {
         parleyNetworkSessionSpy = ParleyNetworkSessionSpy()
-        parleyNetworkSessionSpy.requestMethodParametersHeadersCompletionReturnValue = RequestCancelableStub()
-        parleyNetworkSessionSpy.uploadDataToMethodHeadersReturnValue = RequestCancelableStub()
+        parleyNetworkSessionSpy.requestDataMethodHeadersCompletionReturnValue = RequestCancelableStub()
+        parleyNetworkSessionSpy.uploadDataToMethodHeadersCompletionReturnValue = RequestCancelableStub()
         parleyNetworkSessionSpy.uploadDataToMethodHeadersCompletionReturnValue = RequestCancelableStub()
 
         networkConfig = ParleyNetworkConfig(
             url: "https://api.parley.nu/",
             path: "/example",
-            apiVersion: .v1_6
+            apiVersion: .v1_7
         )
         createSecretMock = { "secret" }
         createUniqueDeviceIdentifierMock = { "id" }
@@ -51,7 +51,6 @@ final class ParleyRemoteTests: XCTestCase {
         sut.execute(
             .get,
             path: "path",
-            parameters: [:],
             keyPath: .none,
             onSuccess: { (items: [MediaResponse]) in
                 XCTAssertEqual(items.count, 1)
@@ -64,7 +63,7 @@ final class ParleyRemoteTests: XCTestCase {
 
         try callRequestCompletion(response: [MediaResponse(media: "test")])
 
-        wait { self.parleyNetworkSessionSpy.requestMethodParametersHeadersCompletionCalled }
+        wait { self.parleyNetworkSessionSpy.requestDataMethodHeadersCompletionCalled }
         XCTAssertTrue(onSuccessCalled)
         XCTAssertFalse(onFailureCalled)
     }
@@ -76,7 +75,6 @@ final class ParleyRemoteTests: XCTestCase {
         sut.execute(
             .get,
             path: "path",
-            parameters: [:],
             keyPath: .none,
             onSuccess: { (_: [MediaResponse]) in
                 onSuccessCalled = true
@@ -88,7 +86,7 @@ final class ParleyRemoteTests: XCTestCase {
 
         try callRequestCompletion(response: ["test"])
 
-        wait { self.parleyNetworkSessionSpy.requestMethodParametersHeadersCompletionCalled }
+        wait { self.parleyNetworkSessionSpy.requestDataMethodHeadersCompletionCalled }
         XCTAssertFalse(onSuccessCalled)
         XCTAssertTrue(onFailureCalled)
     }
@@ -110,7 +108,7 @@ final class ParleyRemoteTests: XCTestCase {
 
         try callRequestCompletion(response: ["test"])
 
-        wait { self.parleyNetworkSessionSpy.requestMethodParametersHeadersCompletionCalled }
+        wait { self.parleyNetworkSessionSpy.requestDataMethodHeadersCompletionCalled }
         XCTAssertTrue(onSuccessCalled)
         XCTAssertFalse(onFailureCalled)
     }
@@ -162,11 +160,11 @@ final class ParleyRemoteTests: XCTestCase {
         wait { self.parleyNetworkSessionSpy.uploadDataToMethodHeadersCompletionCalled }
         XCTAssertTrue(resultCalled)
     }
-    
+
     // MARK: - MultipartFormData
 
     private func callRequestCompletion(response: Encodable) throws {
-        let arguments = parleyNetworkSessionSpy.requestMethodParametersHeadersCompletionReceivedArguments
+        let arguments = parleyNetworkSessionSpy.requestDataMethodHeadersCompletionReceivedArguments
         try arguments?.completion(.success(createResponse(body: CodableHelper.shared.encode(response))))
     }
 

--- a/Tests/ParleyTests/Extensions/Data+appendTests.swift
+++ b/Tests/ParleyTests/Extensions/Data+appendTests.swift
@@ -2,20 +2,20 @@ import XCTest
 @testable import Parley
 
 final class DataAppendTests: XCTestCase {
-    
+
     func testAppendEmptyString() {
         var sut = Data()
         sut.append("", encoding: .utf8)
-        
+
         XCTAssertEqual(String(data: sut, encoding: .utf8), "")
     }
-    
+
     func testAppendString() {
         var sut = Data()
         sut.append("Hello", encoding: .utf8)
         sut.append(" ", encoding: .utf8)
         sut.append("World!", encoding: .utf8)
-        
+
         XCTAssertEqual(String(data: sut, encoding: .utf8), "Hello World!")
     }
 }

--- a/Tests/ParleyTests/TestDoubles/ParleyNetworkSessionSpy.swift
+++ b/Tests/ParleyTests/TestDoubles/ParleyNetworkSessionSpy.swift
@@ -4,37 +4,36 @@ import Foundation
 public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
 
     public init(
-        requestMethodParametersHeadersCompletionReturnValue: ParleyRequestCancelable? = nil,
-        uploadDataToMethodHeadersCompletionReturnValue: ParleyRequestCancelable? = nil,
-        uploadDataToMethodHeadersReturnValue: ParleyRequestCancelable? = nil
+        requestDataMethodHeadersCompletionReturnValue: ParleyRequestCancelable? = nil,
+        uploadDataToMethodHeadersCompletionReturnValue: ParleyRequestCancelable? = nil
     ) {
-        self.requestMethodParametersHeadersCompletionReturnValue = requestMethodParametersHeadersCompletionReturnValue
+        self.requestDataMethodHeadersCompletionReturnValue = requestDataMethodHeadersCompletionReturnValue
         self.uploadDataToMethodHeadersCompletionReturnValue = uploadDataToMethodHeadersCompletionReturnValue
-        self.uploadDataToMethodHeadersReturnValue = uploadDataToMethodHeadersReturnValue
     }
 
     // MARK: - request
 
-    public var requestMethodParametersHeadersCompletionCallsCount = 0
-    public var requestMethodParametersHeadersCompletionCalled: Bool {
-        return requestMethodParametersHeadersCompletionCallsCount > 0
+    public var requestDataMethodHeadersCompletionCallsCount = 0
+    public var requestDataMethodHeadersCompletionCalled: Bool {
+        return requestDataMethodHeadersCompletionCallsCount > 0
     }
-    public var requestMethodParametersHeadersCompletionReceivedArguments: (url: URL, method: ParleyHTTPRequestMethod, parameters: [String: Any]?, headers: [String: String], completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void)?
-    public var requestMethodParametersHeadersCompletionReceivedInvocations: [(url: URL, method: ParleyHTTPRequestMethod, parameters: [String: Any]?, headers: [String: String], completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void)] = []
-    public var requestMethodParametersHeadersCompletionReturnValue: ParleyRequestCancelable!
-    public var requestMethodParametersHeadersCompletionClosure: ((URL, ParleyHTTPRequestMethod, [String: Any]?, [String: String], @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable)?
+    public var requestDataMethodHeadersCompletionReceivedArguments: (url: URL, data: Data?, method: ParleyHTTPRequestMethod, headers: [String: String], completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void)?
+    public var requestDataMethodHeadersCompletionReceivedInvocations: [(url: URL, data: Data?, method: ParleyHTTPRequestMethod, headers: [String: String], completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void)] = []
+    public var requestDataMethodHeadersCompletionReturnValue: ParleyRequestCancelable!
+    public var requestDataMethodHeadersCompletionClosure: ((URL, Data?, ParleyHTTPRequestMethod, [String: String], @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable)?
 
     @discardableResult
-    public func request(_ url: URL, method: ParleyHTTPRequestMethod, parameters: [String: Any]?, headers: [String: String], completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable {
-        requestMethodParametersHeadersCompletionCallsCount += 1
-        requestMethodParametersHeadersCompletionReceivedArguments = (url: url, method: method, parameters: parameters, headers: headers, completion: completion)
-        requestMethodParametersHeadersCompletionReceivedInvocations.append((url: url, method: method, parameters: parameters, headers: headers, completion: completion))
-        if let requestMethodParametersHeadersCompletionClosure = requestMethodParametersHeadersCompletionClosure {
-            return requestMethodParametersHeadersCompletionClosure(url, method, parameters, headers, completion)
+    public func request(_ url: URL, data: Data?, method: ParleyHTTPRequestMethod, headers: [String: String], completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable {
+        requestDataMethodHeadersCompletionCallsCount += 1
+        requestDataMethodHeadersCompletionReceivedArguments = (url: url, data: data, method: method, headers: headers, completion: completion)
+        requestDataMethodHeadersCompletionReceivedInvocations.append((url: url, data: data, method: method, headers: headers, completion: completion))
+        if let requestDataMethodHeadersCompletionClosure = requestDataMethodHeadersCompletionClosure {
+            return requestDataMethodHeadersCompletionClosure(url, data, method, headers, completion)
         } else {
-            return requestMethodParametersHeadersCompletionReturnValue
+            return requestDataMethodHeadersCompletionReturnValue
         }
     }
+
     // MARK: - upload
 
     public var uploadDataToMethodHeadersCompletionCallsCount = 0
@@ -55,29 +54,6 @@ public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
             return uploadDataToMethodHeadersCompletionClosure(data, url, method, headers, completion)
         } else {
             return uploadDataToMethodHeadersCompletionReturnValue
-        }
-    }
-
-    // MARK: - upload
-
-    public var uploadDataToMethodHeadersCallsCount = 0
-    public var uploadDataToMethodHeadersCalled: Bool {
-        return uploadDataToMethodHeadersCallsCount > 0
-    }
-    public var uploadDataToMethodHeadersReceivedArguments: (data: Data, url: URL, method: ParleyHTTPRequestMethod, headers: [String: String])?
-    public var uploadDataToMethodHeadersReceivedInvocations: [(data: Data, url: URL, method: ParleyHTTPRequestMethod, headers: [String: String])] = []
-    public var uploadDataToMethodHeadersReturnValue: ParleyRequestCancelable!
-    public var uploadDataToMethodHeadersClosure: ((Data, URL, ParleyHTTPRequestMethod, [String: String]) -> ParleyRequestCancelable)?
-
-    @discardableResult
-    public func upload(data: Data, to url: URL, method: ParleyHTTPRequestMethod, headers: [String: String]) -> ParleyRequestCancelable {
-        uploadDataToMethodHeadersCallsCount += 1
-        uploadDataToMethodHeadersReceivedArguments = (data: data, url: url, method: method, headers: headers)
-        uploadDataToMethodHeadersReceivedInvocations.append((data: data, url: url, method: method, headers: headers))
-        if let uploadDataToMethodHeadersClosure = uploadDataToMethodHeadersClosure {
-            return uploadDataToMethodHeadersClosure(data, url, method, headers)
-        } else {
-            return uploadDataToMethodHeadersReturnValue
         }
     }
 


### PR DESCRIPTION
As discussed in https://github.com/parley-messaging/ios-library/issues/77 fixed the for the flowing issues: 
- Use `application/json` instead of `multipart/form-data` (your spec of the API does not include JSON but the requests do work https://api.parley.nu/clientApi/v1.8/doc/#operation/PostMessages)
- Improve the `ParleyNetworkSession` interface so you do not need to serialize the data in the implementation of the interface.