### PR TITLE
Make it possible to specify rounding for corners for image

### DIFF
--- a/Sources/Parley/Views/ParleyImageView.swift
+++ b/Sources/Parley/Views/ParleyImageView.swift
@@ -1,32 +1,37 @@
 import UIKit
 
 final class ParleyImageView: UIImageView {
-    
+
     var corners: UIRectCorner = [.allCorners] {
         didSet {
-            if let radius = self.cornerRadius {
-                self.roundCorners(corners: self.corners, radius: radius)
+            if let cornerRadius {
+                roundCorners(corners: corners, radius: cornerRadius)
             }
         }
     }
+
     var cornerRadius: CGFloat? {
         didSet {
-            if let radius = self.cornerRadius {
-                self.roundCorners(corners: self.corners, radius: radius)
+            if let cornerRadius {
+                roundCorners(corners: corners, radius: cornerRadius)
             }
         }
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        
-        if let radius = self.cornerRadius {
-            self.roundCorners(corners: self.corners, radius: radius)
+
+        if let cornerRadius {
+            roundCorners(corners: corners, radius: cornerRadius)
         }
     }
-    
+
     private func roundCorners(corners: UIRectCorner, radius: CGFloat) {
-        let path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        let path = UIBezierPath(
+            roundedRect: bounds,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
         let mask = CAShapeLayer()
         mask.path = path.cgPath
         layer.mask = mask

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
@@ -122,7 +122,7 @@ final class ParleyMessageView: UIView {
     // MARK: - Appearance
     var appearance: ParleyMessageViewAppearance? {
         didSet {
-            guard let appearance = appearance else { return }
+            guard let appearance else { return }
             apply(appearance)
         }
     }
@@ -314,10 +314,24 @@ final class ParleyMessageView: UIView {
     
     private func renderImageCorners() {
         if displayTitle == .message || message.message != nil || message.hasButtons {
-            imageImageView.corners = [.topLeft, .topRight]
+            imageImageView.corners = filterOutCornersIfNecessary(neededCorners: appearance?.imageCorners)
         } else {
-            imageImageView.corners = [.allCorners]
+            imageImageView.corners = appearance?.imageCorners ?? [.allCorners]
         }
+    }
+    
+    private func filterOutCornersIfNecessary(neededCorners: UIRectCorner?) -> UIRectCorner {
+        guard let neededCorners else {
+            return [.topLeft, .topRight]
+        }
+        var filteredCorners: UIRectCorner = []
+        if neededCorners.contains(.topLeft) {
+            filteredCorners.insert(.topLeft)
+        }
+        if neededCorners.contains(.topRight) {
+            filteredCorners.insert(.topRight)
+        }
+        return filteredCorners
     }
     
     private func setImageWidth() {
@@ -520,7 +534,7 @@ final class ParleyMessageView: UIView {
         imageBottomLayoutConstraint.constant = appearance.imageInsets?.bottom ?? 0
         
         imageImageView.cornerRadius = CGFloat(appearance.imageCornerRadius)
-        imageImageView.corners = [.allCorners]
+        imageImageView.corners = appearance.imageCorners
         
         imageActivityIndicatorView.color = appearance.imageLoaderTintColor
         

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
@@ -325,10 +325,10 @@ final class ParleyMessageView: UIView {
             return [.topLeft, .topRight]
         }
         var filteredCorners: UIRectCorner = []
-        if neededCorners.contains(.topLeft) {
+        if neededCorners.contains(.topLeft) || neededCorners.contains(.allCorners) {
             filteredCorners.insert(.topLeft)
         }
-        if neededCorners.contains(.topRight) {
+        if neededCorners.contains(.topRight) || neededCorners.contains(.allCorners) {
             filteredCorners.insert(.topRight)
         }
         return filteredCorners

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewAppearance.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewAppearance.swift
@@ -11,6 +11,7 @@ public class ParleyMessageViewAppearance {
     
     // Image
     public var imageCornerRadius: Float = 20
+    public var imageCorners: UIRectCorner = [.allCorners]
     public var imagePlaceholder: UIImage
     public var imageLoaderTintColor: UIColor = UIColor(white:0, alpha:0.8)
     


### PR DESCRIPTION
I would like to have rounded on some edges of a image not all. This was not possible with the current options of the SDK. I've implemented this in this pr.

With the following config: 
```swift
appearance.userMessage.imageCorners = [.topLeft, .topRight, .bottomLeft]
appearance.agentMessage.imageCorners = [.topLeft, .topRight, .bottomRight] 
```
You will have the following style:
![preview](https://github.com/parley-messaging/ios-library/assets/6486389/092b66ee-d352-4a37-a6ac-ec0ab0f7b6eb)
