### PR TITLE
feat: Make possible to always enable polling of new messages;

### DIFF
--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -50,7 +50,7 @@ public final class Parley {
     private(set) var messageDataSource: ParleyMessageDataSource?
     private(set) var keyValueDataSource: ParleyKeyValueDataSource?
  
-    private(set) var alwaysEnablePolling: Bool = false
+    private(set) var alwaysPolling: Bool = false
     private(set) var pushToken: String? = nil
     private(set) var pushType: Device.PushType? = nil
     private(set) var pushEnabled: Bool = false
@@ -822,9 +822,9 @@ extension Parley {
      Always enable polling of messages even when the push permission is granted.
 
      - Parameters:
-       - enabled: Boolean that indicates if `alwaysEnablePolling` should be enabled.
+       - enabled: Boolean that indicates if `alwaysPolling` should be enabled.
      */
-    public static func setAlwaysEnablePolling(_ enabled: Bool) {
-        shared.alwaysEnablePolling = enabled
+    public static func setAlwaysPolling(_ enabled: Bool) {
+        shared.alwaysPolling = enabled
     }
 }

--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -50,6 +50,7 @@ public final class Parley {
     private(set) var messageDataSource: ParleyMessageDataSource?
     private(set) var keyValueDataSource: ParleyKeyValueDataSource?
  
+    private(set) var alwaysEnablePolling: Bool = false
     private(set) var pushToken: String? = nil
     private(set) var pushType: Device.PushType? = nil
     private(set) var pushEnabled: Bool = false
@@ -815,5 +816,15 @@ extension Parley {
      */
     public static func setReferrer(_ referrer: String) {
         shared.referrer = referrer
+    }
+    
+    /**
+     Always enable polling of messages even when the push permission is granted.
+
+     - Parameters:
+       - enabled: Boolean that indicates if `alwaysEnablePolling` should be enabled.
+     */
+    public static func setAlwaysEnablePolling(_ enabled: Bool) {
+        shared.alwaysEnablePolling = enabled
     }
 }

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -116,7 +116,7 @@ public class ParleyView: UIView {
     private func setupPollingIfNecessary() {
         pollingService.delegate = self
         
-        if Parley.shared.alwaysEnablePolling {
+        if Parley.shared.alwaysPolling {
             pollingService.startRefreshing()
         } else {
             notificationService.notificationsEnabled() { [weak self] isEnabled in

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -115,9 +115,14 @@ public class ParleyView: UIView {
     
     private func setupPollingIfNecessary() {
         pollingService.delegate = self
-        notificationService.notificationsEnabled() { [weak self] isEnabled in
-            guard !isEnabled else { return }
-            self?.pollingService.startRefreshing()
+        
+        if Parley.shared.alwaysEnablePolling {
+            pollingService.startRefreshing()
+        } else {
+            notificationService.notificationsEnabled() { [weak self] isEnabled in
+                guard !isEnabled else { return }
+                self?.pollingService.startRefreshing()
+            }
         }
     }
 


### PR DESCRIPTION
This pr makes it possible to always enable polling even when the push permission is granted. This is a fix for the issue I raised in: https://github.com/parley-messaging/ios-library/issues/82.

It does add the `func setAlwaysEnablePolling(:_)` function to the Parley singleton. The view reads the property to enable the polling if needed;