### PR TITLE
Prevent duplicate creation of classes

### DIFF
--- a/Sources/Parley/Constants.swift
+++ b/Sources/Parley/Constants.swift
@@ -10,9 +10,6 @@ let kParleyUserDefaultDeviceUUID = "parley.device_uuid"
 let kParleyTypeMessage = "message"
 let kParleyTypeEvent = "event"
 
-let kParleyEventStartTyping = "startTyping"
-let kParleyEventStopTyping = "stopTyping"
-
 let kParleyEventStartTypingTriggerAfter = 20.0
 let kParleyEventStopTypingTriggerAfter = 15.0
 

--- a/Sources/Parley/Data/Models/Common/ParleyHTTPDataResponse.swift
+++ b/Sources/Parley/Data/Models/Common/ParleyHTTPDataResponse.swift
@@ -11,16 +11,4 @@ public struct ParleyHTTPDataResponse: ResponseValidator {
         self.statusCode = statusCode
         self.headers = headers
     }
-
-    func decodeAtKeyPath<T: Codable>(of type: T.Type, keyPath: ParleyResponseKeyPath?) throws -> T {
-        guard let body else {
-            throw HTTPResponseError.dataMissing
-        }
-        switch keyPath {
-        case .data:
-            return try CodableHelper.shared.decode(ParleyResponse<T>.self, from: body).data
-        case nil:
-            return try CodableHelper.shared.decode(T.self, from: body)
-        }
-    }
 }

--- a/Sources/Parley/Data/Remotes/EventRemoteService.swift
+++ b/Sources/Parley/Data/Remotes/EventRemoteService.swift
@@ -8,7 +8,7 @@ final class EventRemoteService {
         self.remote = remote
     }
 
-    func fire(_ name: String, onSuccess: @escaping () -> (), onFailure: @escaping (_ error: Error) -> ()) {
-        remote.execute(.post, path: "services/event/\(name)", onSuccess: onSuccess, onFailure: onFailure)
+    func fire(_ name: UserTypingEvent, onSuccess: @escaping () -> (), onFailure: @escaping (_ error: Error) -> ()) {
+        remote.execute(.post, path: "services/event/\(name.rawValue)", onSuccess: onSuccess, onFailure: onFailure)
     }
 }

--- a/Sources/Parley/Data/Remotes/MessageRemoteService.swift
+++ b/Sources/Parley/Data/Remotes/MessageRemoteService.swift
@@ -4,11 +4,9 @@ import UIKit
 final class MessageRemoteService {
 
     private let remote: ParleyRemote
-    private let codableHelper: CodableHelper
 
-    init(remote: ParleyRemote, codableHelper: CodableHelper = .shared) {
+    init(remote: ParleyRemote) {
         self.remote = remote
-        self.codableHelper = codableHelper
     }
 
     func find(_ id: Int, onSuccess: @escaping (_ message: Message) -> (), onFailure: @escaping (_ error: Error) -> ()) {
@@ -87,7 +85,7 @@ final class MessageRemoteService {
         )
     }
 
-    internal func findMedia(_ id: String, result: @escaping (Result<ParleyImageNetworkModel, Error>) -> Void) {
+    func findMedia(_ id: String, result: @escaping (Result<ParleyImageNetworkModel, Error>) -> Void) {
         remote.execute(.get, path: "media/\(id)", result: result)
     }
 }

--- a/Sources/Parley/Data/Remotes/ParleyHTTPDataResponse+decodeAtKeyPath.swift
+++ b/Sources/Parley/Data/Remotes/ParleyHTTPDataResponse+decodeAtKeyPath.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension ParleyHTTPDataResponse {
+
+    func decodeAtKeyPath<T: Codable>(of type: T.Type, keyPath: ParleyResponseKeyPath?) throws -> T {
+        guard let body else {
+            throw HTTPResponseError.dataMissing
+        }
+        switch keyPath {
+        case .data:
+            return try CodableHelper.shared.decode(ParleyResponse<T>.self, from: body).data
+        case nil:
+            return try CodableHelper.shared.decode(T.self, from: body)
+        }
+    }
+}

--- a/Sources/Parley/Data/Remotes/ParleyRemote.swift
+++ b/Sources/Parley/Data/Remotes/ParleyRemote.swift
@@ -89,6 +89,7 @@ final class ParleyRemote {
 
         return try? JSONEncoder().encode(body)
     }
+
     func execute(
         _ method: ParleyHTTPRequestMethod,
         path: String,

--- a/Sources/Parley/Data/Remotes/UserTypingEvent.swift
+++ b/Sources/Parley/Data/Remotes/UserTypingEvent.swift
@@ -1,0 +1,4 @@
+enum UserTypingEvent: String {
+    case startTyping = "startTyping"
+    case stopTyping = "stopTyping"
+}

--- a/Sources/Parley/Data/Repositories/MessageRepository.swift
+++ b/Sources/Parley/Data/Repositories/MessageRepository.swift
@@ -3,12 +3,10 @@ import UIKit
 
 final class MessageRepository {
     
-    private let remote: ParleyRemote
     private let messageRemoteService: MessageRemoteService
     
-    init(remote: ParleyRemote) {
-        self.remote = remote
-        self.messageRemoteService = MessageRemoteService(remote: remote)
+    init(messageRemoteService: MessageRemoteService) {
+        self.messageRemoteService = messageRemoteService
     }
     
     func find(_ id: Int, onSuccess: @escaping (_ message: Message) -> (), onFailure: @escaping (_ error: Error) -> ()) {

--- a/Sources/Parley/Extensions/SymmetricKeyExtension.swift
+++ b/Sources/Parley/Extensions/SymmetricKeyExtension.swift
@@ -1,14 +1,14 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 extension SymmetricKey {
-    
+
     init(key: String, size: SymmetricKeySize = .bits128) throws {
         let keyData = try Self.getKeyData(key)
         try Self.checkSize(key: keyData, size)
         self.init(data: keyData)
     }
-    
+
     private static func getKeyData(_ key: String) throws -> Data {
         guard let keyData = key.data(using: .utf8) else {
             print("Could not create base64 encoded Data from String.")
@@ -16,7 +16,7 @@ extension SymmetricKey {
         }
         return keyData
     }
-    
+
     private static func checkSize(key: Data, _ size: SymmetricKeySize) throws {
         let sizeInBytes = size.bitCount / 8
         guard key.count >= sizeInBytes else {

--- a/Sources/Parley/Extensions/UIViewExtension.swift
+++ b/Sources/Parley/Extensions/UIViewExtension.swift
@@ -10,7 +10,7 @@ extension UIView {
         if let navigationController = viewController as? UINavigationController {
             viewController = navigationController.viewControllers.last
         }
-        
+
         viewController?.present(viewControllerToPresent, animated: true, completion: nil)
     }
     
@@ -21,7 +21,7 @@ extension UIView {
             name: UIAccessibility.voiceOverStatusDidChangeNotification,
             object: nil
         )
-        
+
         // Run callback function immediately
         voiceOverDidChangeNotificationCallback()
     }
@@ -29,7 +29,7 @@ extension UIView {
     @objc private func voiceOverDidChangeNotificationCallback() {
         voiceOverDidChange(isVoiceOverRunning: UIAccessibility.isVoiceOverRunning)
     }
-    
+
     /// Called when VoiceOver status changed.
     /// - Important: Call `watchForVoiceOverDidChangeNotification(observer:)` to get callbacks.
     @objc func voiceOverDidChange(isVoiceOverRunning: Bool) { }

--- a/Sources/Parley/Extensions/UImageExtension.swift
+++ b/Sources/Parley/Extensions/UImageExtension.swift
@@ -1,5 +1,5 @@
-import UIKit
 import ImageIO
+import UIKit
 
 extension UIImageView {
 
@@ -51,7 +51,7 @@ extension UIImage {
     }
 
     class func gif(name: String) -> UIImage? {
-        // Check for existance of gif
+        // Check for existence of gif
         guard let bundleURL = Bundle.main
           .url(forResource: name, withExtension: "gif") else {
             print("SwiftGif: This image named \"\(name)\" does not exist")
@@ -174,8 +174,7 @@ extension UIImage {
             }
 
             // At it's delay in cs
-            let delaySeconds = UIImage.delayForImageAtIndex(Int(index),
-                source: source)
+            let delaySeconds = UIImage.delayForImageAtIndex(Int(index), source: source)
             delays.append(Int(delaySeconds * 1000.0)) // Seconds to ms
         }
 
@@ -188,7 +187,7 @@ extension UIImage {
             }
 
             return sum
-            }()
+        }()
 
         // Get frames
         let gcd = gcdForArray(delays)
@@ -205,8 +204,10 @@ extension UIImage {
             }
         }
 
-        let animation = UIImage.animatedImage(with: frames,
-            duration: Double(duration) / 1000.0)
+        let animation = UIImage.animatedImage(
+            with: frames,
+            duration: Double(duration) / 1000.0
+        )
 
         return animation
     }

--- a/Sources/Parley/PollingService.swift
+++ b/Sources/Parley/PollingService.swift
@@ -18,7 +18,7 @@ final class PollingService: PollingServiceProtocol {
     
     private var timer: Timer?
     weak var delegate: ParleyDelegate?
-    private let messageRepository = MessageRepository(remote: Parley.shared.remote)
+    private let messageRepository = Parley.shared.messageRepository
     private let messagesManager = Parley.shared.messagesManager
     
     private var loopRepeated: Int = 0 {
@@ -65,7 +65,7 @@ final class PollingService: PollingServiceProtocol {
     }
     
     private func refreshFeed() {
-        guard let id = messagesManager?.lastSentMessage?.id, timer?.isValid == true else { return }
+        guard let messageRepository, let id = messagesManager?.lastSentMessage?.id, timer?.isValid == true else { return }
         messageRepository.findAfter(id, onSuccess: { [weak self, weak delegate, weak messagesManager] messageCollection in
             guard !messageCollection.messages.isEmpty else {
                 self?.loopRepeated += 1

--- a/Sources/Parley/Presentation/Models/ImageDisplayModel.swift
+++ b/Sources/Parley/Presentation/Models/ImageDisplayModel.swift
@@ -3,10 +3,10 @@ import UIKit
 struct ImageDisplayModel: Hashable {
     let image: UIImage
     let type: ParleyImageType
-    
+
     init?(data: Data, type: ParleyImageType) {
         self.type = type
-        
+
         switch type {
         case .png, .jpg:
             guard let image = UIImage(data: data) else { return nil }
@@ -16,11 +16,11 @@ struct ImageDisplayModel: Hashable {
             self.image = image
         }
     }
-    
+
     static func from(stored image: ParleyStoredImage) -> Self? {
         ImageDisplayModel(data: image.data, type: image.type)
     }
-    
+
     static func from(remote image: ParleyImageNetworkModel) -> Self? {
         ImageDisplayModel(data: image.data, type: image.type)
     }

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -52,8 +52,8 @@ public class ParleyView: UIView {
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     @IBOutlet weak var statusLabel: UILabel!
     private let notificationService = NotificationService()
-    private var messageRepository: MessageRepository = MessageRepository(remote: Parley.shared.remote)
-    private var pollingService: PollingServiceProtocol = PollingService()
+    private let messageRepository: MessageRepository = Parley.shared.messageRepository
+    private let pollingService: PollingServiceProtocol = PollingService()
     
     private var observeNotificationsBounds: NSKeyValueObservation?
     private var observeSuggestionsBounds: NSKeyValueObservation?


### PR DESCRIPTION
This pr does the following: 
- Do not create multiple `MessageRemoteService`
- Make from TypeEvent a enum.