### PR TITLE
Always call completion of set user information

### DIFF
--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -695,8 +695,8 @@ extension Parley {
      - Parameters:
        - authorization: Authorization of the user.
        - additionalInformation: Additional information of the user.
-       - onSuccess: Execution block when user information is set (only called when Parley is configuring/configured).
-       - onFailure: Execution block when user information is can not be set (only called when Parley is configuring/configured). This block takes an Int which represents the HTTP Status Code and a String describing what went wrong.
+       - onSuccess: Execution block when user information is set.
+       - onFailure: Execution block when user information is can not be set. This block takes an Int which represents the HTTP Status Code and a String describing what went wrong.
      */
     public static func setUserInformation(
         _ authorization: String,
@@ -709,6 +709,8 @@ extension Parley {
 
         if shared.state == .configured {
             shared.reconfigure(onSuccess: onSuccess, onFailure: onFailure)
+        } else {
+            onSuccess?()
         }
     }
 


### PR DESCRIPTION
When you chain the `setUserInformation` and `configure` functions you want to be sure that `setUserInformation` is done before you call `configure`. The first time of using `setUserInformation` it does not give a callback. 
This pr does change that and it does now always call `onSuccess` when done.