### PR TITLE
Make registering of cells more type safe

### DIFF
--- a/Sources/Parley/PollingService.swift
+++ b/Sources/Parley/PollingService.swift
@@ -18,8 +18,8 @@ final class PollingService: PollingServiceProtocol {
     
     private var timer: Timer?
     weak var delegate: ParleyDelegate?
-    private let messageRepository = Parley.shared.messageRepository
-    private let messagesManager = Parley.shared.messagesManager
+    private lazy var messageRepository = Parley.shared.messageRepository
+    private lazy var messagesManager = Parley.shared.messagesManager
     
     private var loopRepeated: Int = 0 {
         didSet {

--- a/Sources/Parley/Views/MessageImageViewController.swift
+++ b/Sources/Parley/Views/MessageImageViewController.swift
@@ -9,7 +9,7 @@ final class MessageImageViewController: UIViewController {
     var message: Message?
     
     private let messageRepository: MessageRepository
-    private let imageLoader: ImageLoader = Parley.shared.imageLoader
+    private lazy var imageLoader: ImageLoader = Parley.shared.imageLoader
     
     init(messageRepository: MessageRepository) {
         self.messageRepository = messageRepository

--- a/Sources/Parley/Views/ParleySuggestionsView/ParleySuggestionsView.swift
+++ b/Sources/Parley/Views/ParleySuggestionsView/ParleySuggestionsView.swift
@@ -10,8 +10,8 @@ final class ParleySuggestionsView: UIView {
     
     @IBOutlet weak var collectionView: UICollectionView! {
         didSet {
-            let suggestionCollectionViewCell = UINib(nibName: "SuggestionCollectionViewCell", bundle: .module)
-            self.collectionView.register(suggestionCollectionViewCell, forCellWithReuseIdentifier: "SuggestionCollectionViewCell")
+            let suggestionCollectionViewCell = UINib(nibName: SuggestionCollectionViewCell.reuseIdentifier, bundle: .module)
+            self.collectionView.register(suggestionCollectionViewCell, forCellWithReuseIdentifier: SuggestionCollectionViewCell.reuseIdentifier)
             
             self.collectionView.dataSource = self
             self.collectionView.delegate = self
@@ -95,18 +95,28 @@ final class ParleySuggestionsView: UIView {
 }
 
 extension ParleySuggestionsView: UICollectionViewDataSource {
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return self.suggestions?.count ?? 0
     }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let suggestionCollectionView = collectionView.dequeueReusableCell(withReuseIdentifier: "SuggestionCollectionViewCell", for: indexPath) as? SuggestionCollectionViewCell else { return UICollectionViewCell() }
-        guard let suggestion = self.suggestions?[indexPath.row] else { return UICollectionViewCell() }
-        
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard
+            let suggestionCollectionView = collectionView.dequeueReusableCell(
+                withReuseIdentifier: SuggestionCollectionViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? SuggestionCollectionViewCell,
+            let suggestion = self.suggestions?[indexPath.row] else
+        {
+            return UICollectionViewCell()
+        }
+
         suggestionCollectionView.appearance = self.appearance.suggestion
         suggestionCollectionView.render(suggestion)
-        
+
         return suggestionCollectionView
     }
 }

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -51,9 +51,9 @@ public class ParleyView: UIView {
 
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     @IBOutlet weak var statusLabel: UILabel!
-    private let notificationService = NotificationService()
-    private let messageRepository: MessageRepository = Parley.shared.messageRepository
-    private let pollingService: PollingServiceProtocol = PollingService()
+    private lazy var notificationService = NotificationService()
+    private lazy var messageRepository: MessageRepository = Parley.shared.messageRepository
+    private lazy var pollingService: PollingServiceProtocol = PollingService()
     
     private var observeNotificationsBounds: NSKeyValueObservation?
     private var observeSuggestionsBounds: NSKeyValueObservation?
@@ -145,12 +145,12 @@ public class ParleyView: UIView {
     // MARK: Views
     private func setupMessagesTableView() {
         let cellIdentifiers = [
-            "InfoTableViewCell",
-            "DateTableViewCell",
-            "LoadingTableViewCell",
+            InfoTableViewCell.reuseIdentifier,
+            DateTableViewCell.reuseIdentifier,
+            LoadingTableViewCell.reuseIdentifier,
             
-            "MessageTableViewCell",
-            "AgentTypingTableViewCell",
+            MessageTableViewCell.reuseIdentifier,
+            AgentTypingTableViewCell.reuseIdentifier,
         ]
 
         cellIdentifiers.forEach { cellIdentifier in
@@ -496,36 +496,36 @@ extension ParleyView: UITableViewDataSource {
 
         switch message.type {
         case .agent?:
-            let messageTableViewCell = tableView.dequeueReusableCell(withIdentifier: "MessageTableViewCell") as! MessageTableViewCell
+            let messageTableViewCell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.reuseIdentifier) as! MessageTableViewCell
             messageTableViewCell.delegate = self
             messageTableViewCell.appearance = appearance.agentMessage
             messageTableViewCell.render(message)
 
             return messageTableViewCell
         case .date?:
-            let dateTableViewCell = tableView.dequeueReusableCell(withIdentifier: "DateTableViewCell") as! DateTableViewCell
+            let dateTableViewCell = tableView.dequeueReusableCell(withIdentifier: DateTableViewCell.reuseIdentifier) as! DateTableViewCell
             dateTableViewCell.appearance = appearance.date
             dateTableViewCell.render(message)
 
             return dateTableViewCell
         case .info?:
-            let infoTableViewCell = tableView.dequeueReusableCell(withIdentifier: "InfoTableViewCell") as! InfoTableViewCell
+            let infoTableViewCell = tableView.dequeueReusableCell(withIdentifier: InfoTableViewCell.reuseIdentifier) as! InfoTableViewCell
             infoTableViewCell.appearance = appearance.info
             infoTableViewCell.render(message)
 
             return infoTableViewCell
         case .loading?:
-            let loadingTableViewCell = tableView.dequeueReusableCell(withIdentifier: "LoadingTableViewCell") as! LoadingTableViewCell
+            let loadingTableViewCell = tableView.dequeueReusableCell(withIdentifier: LoadingTableViewCell.reuseIdentifier) as! LoadingTableViewCell
             loadingTableViewCell.appearance = appearance.loading
 
             return loadingTableViewCell
         case .agentTyping?:
-            let agentTypingTableViewCell = tableView.dequeueReusableCell(withIdentifier: "AgentTypingTableViewCell") as! AgentTypingTableViewCell
+            let agentTypingTableViewCell = tableView.dequeueReusableCell(withIdentifier: AgentTypingTableViewCell.reuseIdentifier) as! AgentTypingTableViewCell
             agentTypingTableViewCell.appearance = appearance.typingBalloon
 
             return agentTypingTableViewCell
         case .user?:
-            let messageTableViewCell = tableView.dequeueReusableCell(withIdentifier: "MessageTableViewCell") as! MessageTableViewCell
+            let messageTableViewCell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.reuseIdentifier) as! MessageTableViewCell
             messageTableViewCell.delegate = self
             messageTableViewCell.appearance = appearance.userMessage
             messageTableViewCell.render(message)

--- a/Sources/Parley/Views/ReusableView.swift
+++ b/Sources/Parley/Views/ReusableView.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UIKit
+
+public protocol ReusableView {
+    static var reuseIdentifier: String { get }
+}
+
+extension ReusableView {
+    public static var reuseIdentifier: String {
+        String(describing: self)
+    }
+}
+
+extension UITableViewCell: ReusableView {}
+extension UITableViewHeaderFooterView: ReusableView {}
+extension UICollectionViewCell: ReusableView {}

--- a/Sources/Parley/Views/ReusableView.swift
+++ b/Sources/Parley/Views/ReusableView.swift
@@ -1,12 +1,12 @@
 import Foundation
 import UIKit
 
-public protocol ReusableView {
+protocol ReusableView {
     static var reuseIdentifier: String { get }
 }
 
 extension ReusableView {
-    public static var reuseIdentifier: String {
+    static var reuseIdentifier: String {
         String(describing: self)
     }
 }

--- a/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCell.swift
+++ b/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCell.swift
@@ -127,20 +127,26 @@ final class MessageTableViewCell: UITableViewCell {
 }
 
 extension MessageTableViewCell: UICollectionViewDataSource {
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         messages?.messages.count ?? 0
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let messageCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: "MessageCollectionViewCell", for: indexPath) as? MessageCollectionViewCell else { return UICollectionViewCell() }
+        guard let messageCollectionViewCell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: MessageCollectionViewCell.reuseIdentifier,
+                for: indexPath
+        ) as? MessageCollectionViewCell else {
+            return UICollectionViewCell()
+        }
 
         messageCollectionViewCell.delegate = self.delegate
         messageCollectionViewCell.appearance = self.appearance?.carousel
-        if let messages = self.messages {
+
+        if let messages {
             messageCollectionViewCell.render(messages.messages[indexPath.row], time: messages.time)
         }
-        
+
         return messageCollectionViewCell
     }
 }


### PR DESCRIPTION
This PR does introduce the following: 
- Lazy ref to the parley singleton + creation of some classes (small performance improvement because they are not always needed). 
- Make the selection of the Cells type safe by introducing a `ReusableView` protocol;