### PR TITLE
Remove register of device on reset.

### DIFF
--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -802,16 +802,9 @@ extension Parley {
         shared.userAuthorization = nil
         shared.userAdditionalInformation = nil
         shared.imageRepository?.reset()
-
-        shared.registerDevice(onSuccess: {
-            shared.secret = nil
-            onSuccess?()
-        }, onFailure: { code, message in
-            shared.secret = nil
-            onFailure?(code, message)
-        })
-
+        shared.secret = nil
         shared.clearChat()
+        onSuccess?()
     }
 
     /**


### PR DESCRIPTION
This PR does introduce the following: 
- Remove the registerDevice call in the `reset` function. Because it is already called on the `configure` function.