### PR TITLE
Fixed camera capture sending the message twice

### DIFF
--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -732,8 +732,6 @@ extension ParleyView: ParleyComposeViewDelegate {
                 presentInformationalAlert(title: title, message: message)
                 return
             }
-
-            await Parley.shared.sendNewMessageWithMedia(mediaModel)
             
             await send(media: mediaModel)
         }


### PR DESCRIPTION
Was introduced by a merge conflict in #116 , this fixes it