### PR TITLE
bugfix: update unit test + fix localization key;

### DIFF
--- a/Sources/Parley/Data/Localization/ParleyLocalizationKey+localized.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationKey+localized.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension ParleyLocalizationKey {
+    var localized: String {
+        Parley.shared.localizationManager.getLocalization(key: self)
+    }
+}

--- a/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
@@ -9,7 +9,7 @@ public enum ParleyLocalizationKey: String {
 
     // MARK: Notifications
     case pushDisabled = "parley_push_disabled"
-    case notificationOffline = "Check your internet connection"
+    case notificationOffline = "parley_notification_offline"
 
     // MARK: Photos
     case photo = "parley_photo"
@@ -55,10 +55,4 @@ public enum ParleyLocalizationKey: String {
     case voiceOverAnnouncementMessageReceived = "parley_voice_over_announcement_message_received"
     case voiceOverAnnouncementInfoMessageReceived = "parley_voice_over_announcement_info_message_received"
     case voiceOverAnnouncementQuickRepliesReceived = "parley_voice_over_announcement_quick_replies_received"
-}
-
-extension ParleyLocalizationKey {
-    var localized: String {
-        Parley.shared.localizationManager.getLocalization(key: self)
-    }
 }

--- a/Tests/ParleyTests/ParleyTests.swift
+++ b/Tests/ParleyTests/ParleyTests.swift
@@ -12,6 +12,8 @@ final class ParleyTests: XCTestCase {
 
     override func tearDownWithError() throws {
         localizationManagerSpy = nil
+
+        Parley.setLocalizationManager(ParleyLocalizationManager())
     }
 
     func testSetLocalizationManager() {


### PR DESCRIPTION
This pr does the following: 
- fix `notificationOffline` key. 
- `ParleyTests` does reset the `LocalizationManager` after running the test.