### PR TITLE
Make sure the pollingService is setup once the messagesManager is available

### DIFF
--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -144,7 +144,7 @@ public class ParleyView: UIView {
     }
 
     private func setupPollingIfNecessary() {
-        guard pollingService != nil,
+        guard pollingService == nil,
               let messagesManager
         else { return }
         
@@ -499,6 +499,8 @@ extension ParleyView: ParleyDelegate {
     func didChangeState(_ state: Parley.State) {
         debugPrint("ParleyViewDelegate.didChangeState:: \(state)")
 
+        setupPollingIfNecessary()
+        
         switch state {
         case .unconfigured:
             messagesTableView.reloadData()


### PR DESCRIPTION
Make sure the pollingService is setup once the messagesManager is available.
When the view is initialised, but Parley is not configured yet, polling service is not configured once the parley is configured. This Pull Request fixes that.