### PR TITLE
Fix issue PollingService is instantiated with previous messagesManager

### DIFF
--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -214,7 +214,7 @@ public final class Parley: ParleyProtocol {
         onFailure: ((_ code: Int, _ message: String) -> Void)? = nil
     ) {
         guard let messagesManager else { fatalError("Missing messages manager (Parley wasn't initialized).") }
-        
+
         debugPrint("Parley.\(#function)")
 
         guard !isLoading else { return }
@@ -384,8 +384,7 @@ public final class Parley: ParleyProtocol {
         guard
             reachable,
             !isLoading,
-            messagesManager.canLoadMore() 
-        else { return }
+            messagesManager.canLoadMore() else { return }
 
         isLoading = true
         messageRepository.findBefore(lastMessageId, onSuccess: { [weak self] messageCollection in
@@ -500,7 +499,7 @@ public final class Parley: ParleyProtocol {
     private func addNewMessage(_ message: Message) async {
         guard let messagesManager else { fatalError("Missing messages manager (Parley wasn't initialized).") }
         userStopTypingTimer?.fire()
-        
+
         let indexPaths = messagesManager.add(message)
         await MainActor.run {
             delegate?.willSend(indexPaths)
@@ -527,8 +526,7 @@ public final class Parley: ParleyProtocol {
         guard let messagesManager else { fatalError("Missing messages manager (Parley wasn't initialized).") }
         guard
             let id = userInfo["id"] as? Int,
-            let typeId = userInfo["typeId"] as? Int 
-        else { return }
+            let typeId = userInfo["typeId"] as? Int else { return }
 
         let body = userInfo["body"] as? String
 

--- a/Tests/ParleyTests/ParleyViewConfigurationTests.swift
+++ b/Tests/ParleyTests/ParleyViewConfigurationTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Parley
+
+final class ParleyViewConfigurationTests: XCTestCase {
+    func testPollingServiceIsRenewedWhenStateBecomesUnconfigured() {
+        let parleyStub = ParleyStub(
+            messagesManager: MessagesManagerStub(),
+            messageRepository: MessageRepositoryStub(),
+            imageLoader: ImageLoaderStub(),
+            localizationManager: ParleyLocalizationManager()
+        )
+
+        let pollingServiceStub = PollingServiceStub()
+
+        let sut = ParleyView(
+            parley: parleyStub,
+            pollingService: pollingServiceStub,
+            notificationService: NotificationServiceStub()
+        )
+
+        XCTAssertTrue(sut.pollingService === pollingServiceStub)
+
+        parleyStub.state = .configured
+
+        let newlyInstantiatedSut = ParleyView(
+            parley: parleyStub,
+            pollingService: nil,
+            notificationService: NotificationServiceStub()
+        )
+
+        XCTAssertNotNil(newlyInstantiatedSut.pollingService)
+
+        parleyStub.messagesManager = nil
+        newlyInstantiatedSut.didChangeState(.unconfigured)
+
+        XCTAssertNil(newlyInstantiatedSut.pollingService)
+
+        parleyStub.messagesManager = MessagesManagerStub()
+        newlyInstantiatedSut.didChangeState(.configured)
+
+        XCTAssertNotNil(newlyInstantiatedSut.pollingService)
+        XCTAssertFalse(newlyInstantiatedSut.pollingService === pollingServiceStub)
+    }
+}

--- a/Tests/ParleyTests/ParleyViewTests.swift
+++ b/Tests/ParleyTests/ParleyViewTests.swift
@@ -317,7 +317,7 @@ final class ParleyViewTests: XCTestCase {
 
         assert(sut: sut)
     }
-    
+
     func testUnConfiguredStateOfNonStubbedParleyView() {
         let sut = ParleyView()
         applySize(sut: sut)


### PR DESCRIPTION
Fix issue that when a ParleyView is initialized after Parly.state got configured and Parley is configured again the pollingService is instantiated with previous messagesManager, [see the test case](https://github.com/parley-messaging/ios-library/compare/develop...nlamah:parley-ios-library:renew-polling-service-when-parley-reconfigures?expand=1#diff-dfb8f8e548093888234851a2d4621ccbeaac08b3500270a46cc5e68432c42844).