### PR TITLE
Remove ParleyRequestCancelable because it is not used + run http requests on background queue;

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ Create your own network session by adhering to the `ParleyNetworkSession` protoc
 
 ```swift
 class CustomNetworkSession : ParleyNetworkSession {
-    func request(_ url: URL, data: Data?, method: ParleyHTTPRequestMethod, headers: [String : String], completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable {
+    func request(_ url: URL, data: Data?, method: ParleyHTTPRequestMethod, headers: [String : String], completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) {
         // ...
     }
     
-    func upload(data: Data, to url: URL, method: ParleyHTTPRequestMethod, headers: [String : String], completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) -> ParleyRequestCancelable {
+    func upload(data: Data, to url: URL, method: ParleyHTTPRequestMethod, headers: [String : String], completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void) {
         // ...
     }
 }

--- a/Sources/Parley/Data/Remotes/MessageRemoteService.swift
+++ b/Sources/Parley/Data/Remotes/MessageRemoteService.swift
@@ -24,12 +24,11 @@ final class MessageRemoteService {
         remote.execute(.get, path: "messages", keyPath: nil, onSuccess: onSuccess, onFailure: onFailure)
     }
 
-    @discardableResult
     func findBefore(
         _ id: Int,
         onSuccess: @escaping (_ messageCollection: MessageCollection) -> Void,
         onFailure: @escaping (_ error: Error) -> Void
-    ) -> ParleyRequestCancelable {
+    ) {
         remote.execute(
             .get,
             path: "messages/before:\(id)",

--- a/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
+++ b/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
@@ -19,21 +19,19 @@ import UIKit
 /// ```
 public protocol ParleyNetworkSession {
 
-    @discardableResult
     func request(
         _ url: URL,
         data: Data?,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable
+    )
 
-    @discardableResult
     func upload(
         data: Data,
         to url: URL,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable
+    )
 }

--- a/Sources/Parley/Data/Remotes/ParleyRequestCancelable.swift
+++ b/Sources/Parley/Data/Remotes/ParleyRequestCancelable.swift
@@ -1,5 +1,1 @@
 import Foundation
-
-public protocol ParleyRequestCancelable {
-    func cancelRequest()
-}

--- a/Sources/Parley/Extensions/DispatchQueue+Queue.swift
+++ b/Sources/Parley/Extensions/DispatchQueue+Queue.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public protocol Queue {
+
+    @preconcurrency
+    func async(execute work: @escaping @Sendable @convention(block) () -> Void)
+
+}
+
+extension DispatchQueue: Queue {
+
+    @preconcurrency
+    public func async(execute work: @escaping @Sendable @convention(block) () -> Void) {
+        async(group: nil, qos: .userInitiated, flags: [], execute: work)
+    }
+}

--- a/Sources/ParleyNetwork/AlamofireNetworkSession.swift
+++ b/Sources/ParleyNetwork/AlamofireNetworkSession.swift
@@ -32,13 +32,13 @@ final class AlamofireNetworkSession: ParleyNetworkSession {
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable {
+    ) {
         var request = URLRequest(url: url)
         request.method = Alamofire.HTTPMethod(method)
         request.headers = HTTPHeaders(headers)
         request.httpBody = data
 
-        let dataRequest = session.request(request).response { response in
+        session.request(request).response { response in
             guard let statusCode = response.response?.statusCode else {
                 completion(.failure(ParleyHTTPErrorResponse(error: HTTPResponseError.dataMissing)))
                 return
@@ -61,8 +61,6 @@ final class AlamofireNetworkSession: ParleyNetworkSession {
                 completion(.failure(responseError))
             }
         }
-
-        return dataRequest
     }
 
     func upload(
@@ -71,7 +69,7 @@ final class AlamofireNetworkSession: ParleyNetworkSession {
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable {
+    ) {
         session.upload(data, to: url, method: Alamofire.HTTPMethod(method), headers: HTTPHeaders(headers))
             .response { response in
                 guard let statusCode = response.response?.statusCode else {

--- a/Sources/ParleyNetwork/Request+RequestCancable.swift
+++ b/Sources/ParleyNetwork/Request+RequestCancable.swift
@@ -1,9 +1,0 @@
-import Alamofire
-import Foundation
-import Parley
-
-extension Request: ParleyRequestCancelable {
-    public func cancelRequest() {
-        cancel()
-    }
-}

--- a/Tests/ParleyTests/Data/Remotes/RequestCancelableStub.swift
+++ b/Tests/ParleyTests/Data/Remotes/RequestCancelableStub.swift
@@ -1,6 +1,0 @@
-import Foundation
-import Parley
-
-struct RequestCancelableStub: ParleyRequestCancelable {
-    func cancelRequest() { }
-}

--- a/Tests/ParleyTests/TestDoubles/ParleyNetworkSessionSpy.swift
+++ b/Tests/ParleyTests/TestDoubles/ParleyNetworkSessionSpy.swift
@@ -3,13 +3,7 @@ import Foundation
 
 public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
 
-    public init(
-        requestDataMethodHeadersCompletionReturnValue: ParleyRequestCancelable? = nil,
-        uploadDataToMethodHeadersCompletionReturnValue: ParleyRequestCancelable? = nil
-    ) {
-        self.requestDataMethodHeadersCompletionReturnValue = requestDataMethodHeadersCompletionReturnValue
-        self.uploadDataToMethodHeadersCompletionReturnValue = uploadDataToMethodHeadersCompletionReturnValue
-    }
+    public init() {}
 
     // MARK: - request
 
@@ -32,23 +26,21 @@ public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
         headers: [String: String],
         completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
     )] = []
-    public var requestDataMethodHeadersCompletionReturnValue: ParleyRequestCancelable!
     public var requestDataMethodHeadersCompletionClosure: ((
         URL,
         Data?,
         ParleyHTTPRequestMethod,
         [String: String],
         @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable)?
+    ) -> Void)?
 
-    @discardableResult
     public func request(
         _ url: URL,
         data: Data?,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable {
+    ) {
         requestDataMethodHeadersCompletionCallsCount += 1
         requestDataMethodHeadersCompletionReceivedArguments = (
             url: url,
@@ -64,11 +56,7 @@ public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
             headers: headers,
             completion: completion
         ))
-        if let requestDataMethodHeadersCompletionClosure = requestDataMethodHeadersCompletionClosure {
-            return requestDataMethodHeadersCompletionClosure(url, data, method, headers, completion)
-        } else {
-            return requestDataMethodHeadersCompletionReturnValue
-        }
+        requestDataMethodHeadersCompletionClosure?(url, data, method, headers, completion)
     }
 
     // MARK: - upload
@@ -92,23 +80,21 @@ public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
         headers: [String: String],
         completion: (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
     )] = []
-    public var uploadDataToMethodHeadersCompletionReturnValue: ParleyRequestCancelable!
     public var uploadDataToMethodHeadersCompletionClosure: ((
         Data,
         URL,
         ParleyHTTPRequestMethod,
         [String: String],
         @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable)?
+    ) -> Void)?
 
-    @discardableResult
     public func upload(
         data: Data,
         to url: URL,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
         completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
-    ) -> ParleyRequestCancelable {
+    ) {
         uploadDataToMethodHeadersCompletionCallsCount += 1
         uploadDataToMethodHeadersCompletionReceivedArguments = (
             data: data,
@@ -124,11 +110,7 @@ public final class ParleyNetworkSessionSpy: ParleyNetworkSession {
             headers: headers,
             completion: completion
         ))
-        if let uploadDataToMethodHeadersCompletionClosure = uploadDataToMethodHeadersCompletionClosure {
-            return uploadDataToMethodHeadersCompletionClosure(data, url, method, headers, completion)
-        } else {
-            return uploadDataToMethodHeadersCompletionReturnValue
-        }
+        uploadDataToMethodHeadersCompletionClosure?(data, url, method, headers, completion)
     }
 
 }

--- a/Tests/ParleyTests/TestDoubles/QueueSpy.swift
+++ b/Tests/ParleyTests/TestDoubles/QueueSpy.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Parley
+
+public final class QueueSpy: Queue {
+
+    public init() {
+        // public init
+    }
+
+    // MARK: - async
+
+    public var asyncExecuteCallsCount = 0
+    public var asyncExecuteCalled: Bool {
+        asyncExecuteCallsCount > 0
+    }
+
+    public var asyncExecuteReceivedWork: (() -> Void)?
+    public var asyncExecuteReceivedInvocations: [() -> Void] = []
+    public var asyncExecuteClosure: ((@convention(block) @escaping () -> Void) -> Void)?
+
+    public func async(execute work: @convention(block) @escaping () -> Void) {
+        asyncExecuteCallsCount += 1
+        asyncExecuteReceivedWork = work
+        asyncExecuteReceivedInvocations.append(work)
+        asyncExecuteClosure?(work)
+    }
+}


### PR DESCRIPTION
In this pr I've done the following improvements: 
- Remove `ParleyRequestCancelable` because it was not used anymore.
- Run all network requests on a background queue to prevent main queue blocking.

Because the `ParleyNetworkSession` protocol did change. This is a breaking change to the project.