### PR TITLE
Remove observers on config reset;

### DIFF
--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -99,10 +99,6 @@ public final class Parley: ParleyProtocol {
     private var userStartTypingDate: Date?
     private var userStopTypingTimer: Timer?
 
-    private init() {
-        addObservers()
-    }
-
     private func initialize(networkConfig: ParleyNetworkConfig, networkSession: ParleyNetworkSession) {
         let remote = ParleyRemote(
             networkConfig: networkConfig,
@@ -126,6 +122,8 @@ public final class Parley: ParleyProtocol {
         imageRepository = ImageRepository(messageRemoteService: messageRemoteService)
         imageRepository.dataSource = imageDataSource
         imageLoader = ImageLoader(imageRepository: imageRepository)
+
+        addObservers()
     }
 
     // MARK: Reachability
@@ -877,12 +875,15 @@ extension Parley {
         shared.userAuthorization = nil
         shared.userAdditionalInformation = nil
         shared.imageRepository?.reset()
+        shared.removeObservers()
 
         shared.registerDevice(onSuccess: {
             shared.secret = nil
+            shared.state = .unconfigured
             onSuccess?()
         }, onFailure: { code, message in
             shared.secret = nil
+            shared.state = .unconfigured
             onFailure?(code, message)
         })
 
@@ -909,6 +910,8 @@ extension Parley {
         shared.imageRepository?.reset()
         shared.secret = nil
         shared.clearChat()
+        shared.removeObservers()
+        shared.state = .unconfigured
         completion?()
     }
 


### PR DESCRIPTION
In the following situation the SDK could crash
- `Parley.configure` is called
- `Parley.purgeLocalMemory` is called
- App moves to the background
- App moves to the forground
- The `registerDevice`call will create a fatal error because the secret is not set anymore. `ParleyRemote.createHeaders#37`.

To solve this issue the observers also need to be removed in the `reset` and `purgeLocalMemory` functions.