### PR TITLE
Feat: Make localization work with arguments

### DIFF
--- a/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedMediaDataSource.swift
+++ b/Sources/Parley/Data/Local/Encrypted/ParleyEncryptedMediaDataSource.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-@available(*, deprecated, renamed: "ParleyEncryptedMediaDataSource", message: "Use ParleyEncryptedMediaDataSource instead")
+@available(
+    *,
+    deprecated,
+    renamed: "ParleyEncryptedMediaDataSource",
+    message: "Use ParleyEncryptedMediaDataSource instead"
+)
 public typealias ParleyEncryptedImageDataSource = ParleyEncryptedMediaDataSource
 
 public class ParleyEncryptedMediaDataSource {
@@ -55,16 +60,16 @@ extension ParleyEncryptedMediaDataSource: ParleyMediaDataSource {
         guard let url = path(id: id) else { return nil }
         return obtainStoredMedia(from: url)
     }
-    
+
     private func path(id: ParleyStoredMedia.ID) -> URL? {
-        return getFiles().first(where: { $0.lastPathComponent.contains(id) })
+        getFiles().first(where: { $0.lastPathComponent.contains(id) })
     }
 
     private func obtainStoredMedia(from url: URL) -> ParleyStoredMedia? {
         guard
             let decryptedData = getDecryptedStoredMediaData(url: url),
             let filePath = ParleyStoredMedia.FilePath.from(url: url) else { return nil }
-        
+
         return ParleyStoredMedia(filename: filePath.name, data: decryptedData, type: filePath.type)
     }
 

--- a/Sources/Parley/Data/Localization/LocalizationManager.swift
+++ b/Sources/Parley/Data/Localization/LocalizationManager.swift
@@ -1,3 +1,3 @@
 public protocol LocalizationManager {
-    func getLocalization(key: ParleyLocalizationKey) -> String
+    func getLocalization(key: ParleyLocalizationKey, arguments: CVarArg...) -> String
 }

--- a/Sources/Parley/Data/Localization/ParleyLocalizationKey+localized.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationKey+localized.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension ParleyLocalizationKey {
-    var localized: String {
-        Parley.shared.localizationManager.getLocalization(key: self)
+    func localized(arguments: CVarArg...) -> String {
+        Parley.shared.localizationManager.getLocalization(key: self, arguments: arguments)
     }
 }

--- a/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
@@ -29,12 +29,12 @@ public enum ParleyLocalizationKey: String {
 
     // MARK: Message
     case messageFileOpen = "parley_message_file_open"
-    
+
     case messageFileLoadFailedNoFileManagerTitle = "parley_message_file_load_failed_no_file_manager_title"
     case messageFileLoadFailedNoFileManagerMessage = "parley_message_file_load_failed_no_file_manager_message"
     case messageFileLoadFailedSavingTitle = "parley_message_file_load_failed_saving_title"
     case messageFileLoadFailedSavingMessage = "parley_message_file_load_failed_saving_message"
-    
+
     // MARK: Message Compose View
     case typeMessage = "parley_type_message"
 

--- a/Sources/Parley/Data/Localization/ParleyLocalizationManager.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationManager.swift
@@ -1,7 +1,12 @@
 import UIKit
 
 struct ParleyLocalizationManager: LocalizationManager {
-    func getLocalization(key: ParleyLocalizationKey) -> String {
-        NSLocalizedString(key.rawValue, bundle: .module, comment: "")
+    func getLocalization(key: ParleyLocalizationKey, arguments: CVarArg...) -> String {
+        let translatedString = NSLocalizedString(key.rawValue, bundle: .module, comment: "")
+        if arguments.isEmpty {
+            return translatedString
+        } else {
+            return String(format: translatedString, locale: nil, arguments: arguments)
+        }
     }
 }

--- a/Sources/Parley/Data/Models/AccesssibilityHelpers/MessageAccessibility.swift
+++ b/Sources/Parley/Data/Models/AccesssibilityHelpers/MessageAccessibility.swift
@@ -23,21 +23,20 @@ extension Message {
             switch message.type {
             case .agent, .systemMessageAgent:
                 if let agentName = message.agent?.name {
-                    let format = ParleyLocalizationKey.voiceOverMessageFromAgentName.localized
-                    return .localizedStringWithFormat(format, agentName)
+                    ParleyLocalizationKey.voiceOverMessageFromAgentName.localized(arguments: agentName)
                 } else {
-                    return ParleyLocalizationKey.voiceOverMessageFromAgent.localized
+                    ParleyLocalizationKey.voiceOverMessageFromAgent.localized()
                 }
             case .user, .systemMessageUser:
-                return ParleyLocalizationKey.voiceOverMessageFromYou.localized
+                ParleyLocalizationKey.voiceOverMessageFromYou.localized()
             case .loading:
-                return ParleyLocalizationKey.voiceOverMessageLoading.localized
+                ParleyLocalizationKey.voiceOverMessageLoading.localized()
             case .agentTyping:
-                return ParleyLocalizationKey.voiceOverMessageAgentIsTyping.localized
+                ParleyLocalizationKey.voiceOverMessageAgentIsTyping.localized()
             case .info, .auto:
-                return ParleyLocalizationKey.voiceOverMessageInformational.localized
+                ParleyLocalizationKey.voiceOverMessageInformational.localized()
             default:
-                return nil
+                nil
             }
         }
 
@@ -68,7 +67,7 @@ extension Message {
 
         private static func createMediumAttachedLabelIfAvailable(_ message: Message) -> String? {
             guard message.hasMedium else { return nil }
-            return ParleyLocalizationKey.voiceOverMessageMediaAttached.localized
+            return ParleyLocalizationKey.voiceOverMessageMediaAttached.localized()
         }
 
         // MARK: Accessibility Label - Ending
@@ -83,9 +82,9 @@ extension Message {
         private static func createStatusLabelIfNeeded(_ message: Message) -> String? {
             switch message.status {
             case .failed:
-                ParleyLocalizationKey.voiceOverMessageFailed.localized
+                ParleyLocalizationKey.voiceOverMessageFailed.localized()
             case .pending:
-                ParleyLocalizationKey.voiceOverMessagePending.localized
+                ParleyLocalizationKey.voiceOverMessagePending.localized()
             case .success:
                 nil
             }
@@ -93,8 +92,7 @@ extension Message {
 
         private static func createTimeLabelIfAvailable(_ message: Message) -> String? {
             guard let time = message.time else { return nil }
-            let format = ParleyLocalizationKey.voiceOverMessageTime.localized
-            return .localizedStringWithFormat(format, time.asTime())
+            return ParleyLocalizationKey.voiceOverMessageTime.localized(arguments: time.asTime())
         }
     }
 }
@@ -108,17 +106,17 @@ extension Message.Accessibility {
         switch message.type {
         case .agent, .systemMessageAgent:
             if message.quickReplies?.isEmpty == false {
-                return ParleyLocalizationKey.voiceOverAnnouncementQuickRepliesReceived.localized
+                return ParleyLocalizationKey.voiceOverAnnouncementQuickRepliesReceived.localized()
             } else {
                 messageArray = [
-                    ParleyLocalizationKey.voiceOverAnnouncementMessageReceived.localized,
+                    ParleyLocalizationKey.voiceOverAnnouncementMessageReceived.localized(),
                     Self.getAccessibilityLabelDescription(for: message),
                     Self.createActionsAttachedLabelIfAvailable(message),
                 ]
             }
         case .info, .auto:
             messageArray = [
-                ParleyLocalizationKey.voiceOverAnnouncementInfoMessageReceived.localized,
+                ParleyLocalizationKey.voiceOverAnnouncementInfoMessageReceived.localized(),
                 message.message,
             ]
         default:
@@ -135,7 +133,7 @@ extension Message.Accessibility {
 
     private static func createActionsAttachedLabelIfAvailable(_ message: Message) -> String? {
         guard message.hasButtons else { return nil }
-        return ParleyLocalizationKey.voiceOverMessageActionsAttached.localized
+        return ParleyLocalizationKey.voiceOverMessageActionsAttached.localized()
     }
 }
 

--- a/Sources/Parley/Data/Models/MediaModel.swift
+++ b/Sources/Parley/Data/Models/MediaModel.swift
@@ -11,7 +11,7 @@ struct MediaModel: Codable {
         type = .map(from: url)
         self.data = data
     }
-    
+
     init?(image: UIImage, data: Data, url: URL) {
         filename = url.lastPathComponent
         type = .map(from: url)

--- a/Sources/Parley/Data/Models/MediaObject.swift
+++ b/Sources/Parley/Data/Models/MediaObject.swift
@@ -4,25 +4,28 @@ import UIKit
 struct MediaObject: Codable {
     let id: String
     let mimeType: String
-    
+
     func getMediaType() -> ParleyMediaType {
-        return ParleyMediaType.from(mimeType: mimeType);
+        ParleyMediaType.from(mimeType: mimeType);
     }
-    
+
     func imageFromData(_ imageData: Data) -> UIImage? {
         if getMediaType() == .imageGif {
-            return UIImage.gif(data: imageData)
+            UIImage.gif(data: imageData)
         } else {
-            return UIImage(data: imageData)
+            UIImage(data: imageData)
         }
     }
-    
-    /// Returns a displayable file name for a MediaObject. 
+
+    /// Returns a displayable file name for a MediaObject.
     ///
     /// The **displayFileName** is not used to reference the file name in local storage and as such can not be used to retrieve the file from local storage.
     /// - Returns: A file name to display to the user
     var displayFileName: String {
-        let filePath = ParleyStoredMedia.FilePath.from(media: self) ?? ParleyStoredMedia.FilePath(name: UUID().uuidString, type: .applicationPdf)
+        let filePath = ParleyStoredMedia.FilePath.from(media: self) ?? ParleyStoredMedia.FilePath(
+            name: UUID().uuidString,
+            type: .applicationPdf
+        )
         return filePath.fileName
     }
 }

--- a/Sources/Parley/Data/Models/Message.swift
+++ b/Sources/Parley/Data/Models/Message.swift
@@ -55,11 +55,11 @@ public final class Message: Codable, Equatable {
     var hasMedium: Bool {
         media != nil
     }
-    
+
     var hasImage: Bool {
         media?.getMediaType().isImageType == true
     }
-    
+
     var hasFile: Bool {
         media?.getMediaType().isImageType == false
     }

--- a/Sources/Parley/Data/Models/ParleyErrorResponse/NotificationErrors/MediaUploadNotificationErrorKind.swift
+++ b/Sources/Parley/Data/Models/ParleyErrorResponse/NotificationErrors/MediaUploadNotificationErrorKind.swift
@@ -11,9 +11,9 @@ enum MediaUploadNotificationErrorKind: String, Error, CaseIterable, Codable {
     var formattedMessage: String {
         switch self {
         case .invalidMediaType, .missingMedia, .couldNotSaveMedia:
-            ParleyLocalizationKey.messageMetaFailedToSend.localized
+            ParleyLocalizationKey.messageMetaFailedToSend.localized()
         case .mediaTooLarge:
-            ParleyLocalizationKey.messageMetaMediaTooLarge.localized
+            ParleyLocalizationKey.messageMetaMediaTooLarge.localized()
         }
     }
 }

--- a/Sources/Parley/Data/Models/ParleyMediaType.swift
+++ b/Sources/Parley/Data/Models/ParleyMediaType.swift
@@ -1,7 +1,7 @@
 import Foundation
+import MobileCoreServices
 import UIKit
 import UniformTypeIdentifiers
-import MobileCoreServices
 
 enum ParleyMediaType: String, CaseIterable, Codable {
     case imagePng = "image/png"
@@ -26,7 +26,7 @@ enum ParleyMediaType: String, CaseIterable, Codable {
             ".bin"
         }
     }
-    
+
     var isImageType: Bool {
         switch self {
         case .imagePng, .imageGif, .imageJPeg:
@@ -35,11 +35,11 @@ enum ParleyMediaType: String, CaseIterable, Codable {
             false
         }
     }
-    
+
     @available(iOS 14.0, *)
     static var documentContentTypes: [UTType] = {
         var types: [UTType] = []
-        ParleyMediaType.allCases.forEach { mediaType in
+        for mediaType in ParleyMediaType.allCases {
             switch mediaType {
             case .imagePng, .imageGif, .imageJPeg, .other:
                 break
@@ -47,13 +47,13 @@ enum ParleyMediaType: String, CaseIterable, Codable {
                 types.append(.pdf)
             }
         }
-        
+
         return types
     }()
-    
+
     static var documentTypes: [String] = {
         var types: [String] = []
-        ParleyMediaType.allCases.forEach { mediaType in
+        for mediaType in ParleyMediaType.allCases {
             switch mediaType {
             case .imagePng, .imageGif, .imageJPeg, .other:
                 break
@@ -61,7 +61,7 @@ enum ParleyMediaType: String, CaseIterable, Codable {
                 types.append(String(kUTTypePDF))
             }
         }
-        
+
         return types
     }()
 
@@ -73,7 +73,7 @@ enum ParleyMediaType: String, CaseIterable, Codable {
     static func from(mimeType: String) -> ParleyMediaType {
         ParleyMediaType(rawValue: mimeType) ?? .other
     }
-    
+
     /// Returns a ParleyMediaType from a given URL
     /// Defaults to .other.
     /// - Parameters:

--- a/Sources/Parley/Data/Models/ParleyStoredMedia.swift
+++ b/Sources/Parley/Data/Models/ParleyStoredMedia.swift
@@ -42,27 +42,30 @@ public struct ParleyStoredMedia: Codable {
         }
 
         static func from(media: MediaObject) -> FilePath? {
-            return .from(id: media.id, type: media.getMediaType())
+            .from(id: media.id, type: media.getMediaType())
         }
-        
+
         static func from(id: String, type: ParleyMediaType) -> FilePath? {
             guard let fileName = decodeFileName(id: id) else {
                 return nil
             }
             return FilePath(name: fileName, type: type)
         }
-        
+
         static func from(url: URL) -> FilePath? {
             let type = ParleyMediaType.map(from: url)
             guard let fileName = decodeFileName(id: url.absoluteString) else {
                 return nil
             }
-            
+
             return FilePath(name: fileName, type: type)
         }
 
         private static func decodeFileName(id: String) -> String? {
-            guard var splitFilename = id.split(separator: "/").last?.split(separator: "."), splitFilename.count >= 2 else {
+            guard
+                var splitFilename = id.split(separator: "/").last?.split(separator: "."),
+                splitFilename.count >= 2 else
+            {
                 return nil
             }
 

--- a/Sources/Parley/Data/ParleyFileManager.swift
+++ b/Sources/Parley/Data/ParleyFileManager.swift
@@ -1,37 +1,39 @@
 import Foundation
 
 class ParleyFileManager {
-    
+
     private let fileManager: FileManager = .default
     private let destination: URL
-    
+
     init() throws {
         destination = fileManager.temporaryDirectory.appendingPathComponent(kParleyCacheFilesDirectory)
         try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
     }
-    
+
     func save(fileData: Data, for media: MediaObject) -> URL? {
-        guard let path = path(for: media),
-              fileManager.createFile(atPath: path.path, contents: fileData) else {
+        guard
+            let path = path(for: media),
+            fileManager.createFile(atPath: path.path, contents: fileData) else
+        {
             return nil
         }
-        
+
         return path
     }
-    
+
     func file(for media: MediaObject) -> Data? {
         guard let path = path(for: media) else {
             return nil
         }
-        
+
         return fileManager.contents(atPath: path.path)
     }
-    
+
     func path(for media: MediaObject) -> URL? {
         guard let fileName = ParleyStoredMedia.FilePath.from(media: media)?.fileName else {
             return nil
         }
-        
+
         return destination.appendingPathComponent(fileName)
     }
 }

--- a/Sources/Parley/Data/Repositories/MediaRepository.swift
+++ b/Sources/Parley/Data/Repositories/MediaRepository.swift
@@ -18,9 +18,9 @@ class MediaRepository {
         store(media: storedMedia)
         return storedMedia
     }
-    
+
     func getStoredMedia(for media: MediaObject) -> ParleyStoredMedia? {
-        return dataSource?.media(id: media.id)
+        dataSource?.media(id: media.id)
     }
 
     func getRemoteMedia(for media: MediaObject) async throws -> Data {
@@ -45,9 +45,9 @@ class MediaRepository {
                 guard let self else { return }
                 do {
                     let mediaResponse = try mediaResult.get()
-                    
+
                     move(storedMedia, to: mediaResponse.media)
-                    
+
                     continuation.resume(returning: mediaResponse.media)
                 } catch {
                     continuation.resume(throwing: error)
@@ -90,7 +90,7 @@ extension MediaRepository {
         let storedMedia = ParleyStoredMedia(filename: remoteId, data: local.data, type: local.type)
         store(media: storedMedia)
     }
-    
+
     private func storeMedia(data: Data, for media: MediaObject) {
         guard let filePath = ParleyStoredMedia.FilePath.from(media: media) else { return }
         let storedMedia = ParleyStoredMedia(filename: filePath.name, data: data, type: filePath.type)

--- a/Sources/Parley/Data/ShareManager.swift
+++ b/Sources/Parley/Data/ShareManager.swift
@@ -5,29 +5,29 @@ protocol ShareManagerProtocol {
 }
 
 class ShareManager: ShareManagerProtocol {
-    
+
     enum ShareManagerError: Error {
         case unableToSaveFile(id: String)
     }
-    
+
     private let fileManager: ParleyFileManager
     private let mediaLoader: MediaLoaderProtocol
-    
+
     init(mediaLoader: MediaLoaderProtocol) throws {
         self.mediaLoader = mediaLoader
-        self.fileManager = try ParleyFileManager()
+        fileManager = try ParleyFileManager()
     }
-    
+
     func share(media: MediaObject) async throws -> URL {
         if fileManager.file(for: media) != nil, let url = fileManager.path(for: media) {
             return url
         }
-        
+
         let data = try await mediaLoader.load(media: media)
         guard let url = fileManager.save(fileData: data, for: media) else {
             throw ShareManagerError.unableToSaveFile(id: media.id)
         }
-        
+
         return url
     }
 }

--- a/Sources/Parley/Parley.swift
+++ b/Sources/Parley/Parley.swift
@@ -161,7 +161,11 @@ public final class Parley: ParleyProtocol {
     }
 
     private func removeObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
@@ -620,7 +624,7 @@ public final class Parley: ParleyProtocol {
         if agentReallyStartTyping {
             UIAccessibility.post(
                 notification: .announcement,
-                argument: ParleyLocalizationKey.voiceOverAnnouncementAgentTyping.localized
+                argument: ParleyLocalizationKey.voiceOverAnnouncementAgentTyping.localized()
             )
             delegate?.didStartTyping()
         }
@@ -676,9 +680,9 @@ extension Parley {
 
     @available(
         *,
-         deprecated,
-         renamed: "enableOfflineMessaging(messageDataSource:keyValueDataSource:mediaDataSource:)",
-         message: "Use enableOfflineMessaging(messageDataSource:keyValueDataSource:mediaDataSource:) instead"
+        deprecated,
+        renamed: "enableOfflineMessaging(messageDataSource:keyValueDataSource:mediaDataSource:)",
+        message: "Use enableOfflineMessaging(messageDataSource:keyValueDataSource:mediaDataSource:) instead"
     )
     public static func enableOfflineMessaging(
         messageDataSource: ParleyMessageDataSource,
@@ -688,10 +692,10 @@ extension Parley {
         enableOfflineMessaging(
             messageDataSource: messageDataSource,
             keyValueDataSource: keyValueDataSource,
-            mediaDataSource: imageDataSource)
+            mediaDataSource: imageDataSource
+        )
     }
 
-    
     /**
      Enable offline messaging.
 

--- a/Sources/Parley/Views/CollectionViewCells/MessageCollectionViewCell/MessageCollectionViewCell.swift
+++ b/Sources/Parley/Views/CollectionViewCells/MessageCollectionViewCell/MessageCollectionViewCell.swift
@@ -65,7 +65,7 @@ final class MessageCollectionViewCell: UICollectionViewCell {
         totalHeight += appearance.balloonContentInsets?.top ?? 0
         totalHeight += appearance.balloonContentInsets?.bottom ?? 0
 
-        var showTopSeparator: Bool = true
+        var showTopSeparator = true
         if message.hasImage {
             totalHeight += 160
 
@@ -94,7 +94,7 @@ final class MessageCollectionViewCell: UICollectionViewCell {
                 font: appearance.messageTextViewAppearance.regularFont
             )
         }
-        
+
         if message.hasFile {
             if showTopSeparator {
                 // Top separator
@@ -102,32 +102,38 @@ final class MessageCollectionViewCell: UICollectionViewCell {
                 totalHeight += appearance.separatorInset?.bottom ?? 0
                 totalHeight += 1
             }
-            
+
             totalHeight += appearance.fileContentInsets?.top ?? 0
             totalHeight += appearance.fileContentInsets?.bottom ?? 0
             totalHeight += max(
-                ParleyLocalizationKey.messageFileOpen.localized.height(withConstrainedWidth: contentWidth, font: appearance.buttonFont),
-                message.media?.displayFileName.height(withConstrainedWidth: contentWidth, font: appearance.fileNameFont) ?? 0
+                ParleyLocalizationKey.messageFileOpen.localized().height(
+                    withConstrainedWidth: contentWidth,
+                    font: appearance.buttonFont
+                ),
+                message.media?.displayFileName.height(
+                    withConstrainedWidth: contentWidth,
+                    font: appearance.fileNameFont
+                ) ?? 0
             )
-            
+
             // Bottom separator
             totalHeight += appearance.separatorInset?.top ?? 0
             totalHeight += appearance.separatorInset?.bottom ?? 0
             totalHeight += 1
-            
+
             showTopSeparator = false
         }
 
         if message.hasButtons {
             totalHeight += appearance.buttonsInsets?.top ?? 0
             totalHeight += appearance.buttonsInsets?.bottom ?? 0
-            
+
             var buttonWidth = balloonWidth
             buttonWidth -= appearance.buttonsInsets?.left ?? 0
             buttonWidth -= appearance.buttonsInsets?.right ?? 0
             buttonWidth -= appearance.buttonInsets?.left ?? 0
             buttonWidth -= appearance.buttonInsets?.right ?? 0
-            
+
             if showTopSeparator {
                 totalHeight += 1 // Initial separator
                 totalHeight += appearance.separatorInset?.top ?? 0
@@ -146,7 +152,7 @@ final class MessageCollectionViewCell: UICollectionViewCell {
                 totalHeight += appearance.balloonContentTextInsets?.top ?? 0
             }
         }
-        
+
         if message.message != nil || message.title != nil || message.hasButtons || !message.hasImage {
             totalHeight += appearance.metaInsets?.top ?? 0
             totalHeight += appearance.metaInsets?.bottom ?? 0

--- a/Sources/Parley/Views/CollectionViewCells/MessageCollectionViewCell/MessageCollectionViewCellAppearance.swift
+++ b/Sources/Parley/Views/CollectionViewCells/MessageCollectionViewCell/MessageCollectionViewCellAppearance.swift
@@ -35,8 +35,8 @@ public class MessageCollectionViewCellAppearance: ParleyMessageViewAppearance {
         appearance.balloonContentTextInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
         appearance.messageTextViewAppearance.textColor = UIColor.white
-        appearance.messageTextViewAppearance.linkTintColor =  UIColor(white: 1, alpha: 0.6)
-        
+        appearance.messageTextViewAppearance.linkTintColor = UIColor(white: 1, alpha: 0.6)
+
         appearance.fileIconTintColor = UIColor(red: 0.6, green: 0.81, blue: 1, alpha: 1.0)
         appearance.fileNameColor = UIColor.white
         appearance.fileActionColor = UIColor(red: 0.6, green: 0.81, blue: 1, alpha: 1.0)

--- a/Sources/Parley/Views/MessageImageViewController.swift
+++ b/Sources/Parley/Views/MessageImageViewController.swift
@@ -94,12 +94,14 @@ final class MessageImageViewController: UIViewController {
 
         Task {
             defer { stopImageLoading() }
-            guard let mediaData = try? await mediaLoader.load(media: media),
-                  let image = media.imageFromData(mediaData) else {
+            guard
+                let mediaData = try? await mediaLoader.load(media: media),
+                let image = media.imageFromData(mediaData) else
+            {
                 displayFailedLoadingImage()
                 return
             }
-            
+
             display(image: image)
         }
     }
@@ -154,7 +156,7 @@ final class MessageImageViewController: UIViewController {
         button.setImage(image, for: .normal)
         button.tintColor = .white
         button.isAccessibilityElement = true
-        button.accessibilityLabel = ParleyLocalizationKey.close.localized
+        button.accessibilityLabel = ParleyLocalizationKey.close.localized()
 
         view.addSubview(button)
 

--- a/Sources/Parley/Views/ParleyComposeView/ParleyComposeView.swift
+++ b/Sources/Parley/Views/ParleyComposeView/ParleyComposeView.swift
@@ -1,8 +1,8 @@
+import MobileCoreServices
 import Photos
 import PhotosUI
-import UniformTypeIdentifiers
-import MobileCoreServices
 import UIKit
+import UniformTypeIdentifiers
 
 public class ParleyComposeView: UIView {
 
@@ -14,7 +14,7 @@ public class ParleyComposeView: UIView {
 
     @IBOutlet weak var mediaUploadButton: UIButton! {
         didSet {
-            mediaUploadButton.accessibilityLabel = ParleyLocalizationKey.voiceOverCameraButtonLabel.localized
+            mediaUploadButton.accessibilityLabel = ParleyLocalizationKey.voiceOverCameraButtonLabel.localized()
         }
     }
 
@@ -40,7 +40,7 @@ public class ParleyComposeView: UIView {
 
             textView.accessibilityCustomActions = [
                 UIAccessibilityCustomAction(
-                    name: ParleyLocalizationKey.voiceOverDismissKeyboardAction.localized,
+                    name: ParleyLocalizationKey.voiceOverDismissKeyboardAction.localized(),
                     target: self,
                     selector: #selector(dismissKeyboard)
                 ),
@@ -68,7 +68,7 @@ public class ParleyComposeView: UIView {
     @IBOutlet weak var sendButton: UIButton! {
         didSet {
             sendButton.layer.cornerRadius = sendButton.bounds.height / 2
-            sendButton.accessibilityLabel = ParleyLocalizationKey.voiceOverSendButtonLabel.localized
+            sendButton.accessibilityLabel = ParleyLocalizationKey.voiceOverSendButtonLabel.localized()
 
             sendButtonEnabledObservation = observe(\.sendButton?.isEnabled, options: [.new]) { [weak self] _, change in
                 let isEnabled = change.newValue
@@ -76,7 +76,8 @@ public class ParleyComposeView: UIView {
                 if isEnabled == true {
                     self?.sendButton.accessibilityHint = nil
                 } else {
-                    self?.sendButton.accessibilityHint = ParleyLocalizationKey.voiceOverSendButtonDisabledHint.localized
+                    self?.sendButton.accessibilityHint = ParleyLocalizationKey.voiceOverSendButtonDisabledHint
+                        .localized()
                 }
             }
         }
@@ -274,35 +275,35 @@ public class ParleyComposeView: UIView {
             popoverController.sourceRect = sender.bounds
             popoverController.permittedArrowDirections = [.left, .down]
         }
-        
-        alertController.title = ParleyLocalizationKey.photo.localized
+
+        alertController.title = ParleyLocalizationKey.photo.localized()
         if isCameraAvailable() {
             alertController.addAction(UIAlertAction(
-                title: ParleyLocalizationKey.takePhoto.localized,
+                title: ParleyLocalizationKey.takePhoto.localized(),
                 style: .default,
                 handler: { [weak self] _ in
                     self?.takePhoto()
                 }
             ))
         }
-        
+
         alertController.addAction(UIAlertAction(
-            title: ParleyLocalizationKey.selectPhoto.localized,
+            title: ParleyLocalizationKey.selectPhoto.localized(),
             style: .default,
             handler: { [weak self] _ in
                 self?.selectPhoto()
             }
         ))
-        
+
         alertController.addAction(UIAlertAction(
-            title: ParleyLocalizationKey.uploadFile.localized,
+            title: ParleyLocalizationKey.uploadFile.localized(),
             style: .default,
             handler: { [weak self] _ in
                 self?.uploadFile()
             }
         ))
 
-        alertController.addAction(UIAlertAction(title: ParleyLocalizationKey.cancel.localized, style: .cancel))
+        alertController.addAction(UIAlertAction(title: ParleyLocalizationKey.cancel.localized(), style: .cancel))
 
         present(alertController, animated: true, completion: nil)
     }
@@ -378,25 +379,24 @@ public class ParleyComposeView: UIView {
 
     private func showPhotoAccessDeniedAlertController() {
         let alertController = UIAlertController(
-            title: ParleyLocalizationKey.photoAccessDeniedTitle.localized,
-            message: ParleyLocalizationKey.photoAccessDeniedBody.localized,
+            title: ParleyLocalizationKey.photoAccessDeniedTitle.localized(),
+            message: ParleyLocalizationKey.photoAccessDeniedBody.localized(),
             preferredStyle: .alert
         )
 
         alertController.addAction(UIAlertAction(
-            title: ParleyLocalizationKey.ok.localized,
+            title: ParleyLocalizationKey.ok.localized(),
             style: .cancel
         ))
 
         present(alertController, animated: true, completion: nil)
     }
-    
+
     private func uploadFile() {
-        let documentPicker: UIDocumentPickerViewController
-        if #available(iOS 14.0, *) {
-            documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: ParleyMediaType.documentContentTypes, asCopy: true)
+        let documentPicker = if #available(iOS 14.0, *) {
+            UIDocumentPickerViewController(forOpeningContentTypes: ParleyMediaType.documentContentTypes, asCopy: true)
         } else {
-            documentPicker = UIDocumentPickerViewController(documentTypes: ParleyMediaType.documentTypes, in: .import)
+            UIDocumentPickerViewController(documentTypes: ParleyMediaType.documentTypes, in: .import)
         }
         documentPicker.delegate = self
         present(documentPicker, animated: true, completion: nil)
@@ -514,12 +514,12 @@ extension ParleyComposeView: UIImagePickerControllerDelegate {
 }
 
 extension ParleyComposeView: UIDocumentPickerDelegate {
-    
+
     public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         guard let selectedFileURL = urls.first else {
             return
         }
-        
+
         delegate?.send(file: selectedFileURL)
     }
 }
@@ -559,13 +559,13 @@ extension ParleyComposeView: PHPickerViewControllerDelegate {
     private func handleUnableToLoadImage(_ error: Error? = nil) async {
         await MainActor.run {
             let alertController = UIAlertController(
-                title: ParleyLocalizationKey.sendFailedTitle.localized,
-                message: ParleyLocalizationKey.sendFailedBodyMediaInvalid.localized,
+                title: ParleyLocalizationKey.sendFailedTitle.localized(),
+                message: ParleyLocalizationKey.sendFailedBodyMediaInvalid.localized(),
                 preferredStyle: .alert
             )
 
             alertController.addAction(UIAlertAction(
-                title: ParleyLocalizationKey.ok.localized,
+                title: ParleyLocalizationKey.ok.localized(),
                 style: .cancel
             ))
 

--- a/Sources/Parley/Views/ParleyComposeView/ParleyComposeViewAppearance.swift
+++ b/Sources/Parley/Views/ParleyComposeView/ParleyComposeViewAppearance.swift
@@ -16,6 +16,7 @@ public class ParleyComposeViewAppearance {
             mediaIcon = cameraIcon
         }
     }
+
     @available(*, deprecated, renamed: "mediaTintColor", message: "Replace with `mediaTintColor` instead.")
     public var cameraTintColor: UIColor {
         get {
@@ -25,6 +26,7 @@ public class ParleyComposeViewAppearance {
             mediaTintColor = cameraTintColor
         }
     }
+
     public var mediaIcon: UIImage
     public var mediaTintColor = UIColor(red: 0.29, green: 0.37, blue: 0.51, alpha: 1.0)
 

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
@@ -57,7 +57,7 @@ final class ParleyMessageView: UIView {
     @IBOutlet private weak var imageMetaStatusImageViewWidth: NSLayoutConstraint!
 
     @IBOutlet private weak var imageFailureMessageLabel: UILabel!
-    
+
     // Name
     @IBOutlet private weak var nameView: UIView!
     @IBOutlet private weak var nameLabel: UILabel!
@@ -84,7 +84,7 @@ final class ParleyMessageView: UIView {
     @IBOutlet private weak var messageLeftLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var messageRightLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var messageBottomLayoutConstraint: NSLayoutConstraint!
-    
+
     // File
     @IBOutlet private weak var fileView: UIView!
     @IBOutlet private weak var fileStackView: UIStackView!
@@ -92,14 +92,14 @@ final class ParleyMessageView: UIView {
     @IBOutlet private weak var fileIcon: UIImageView!
     @IBOutlet private weak var fileLabel: UILabel!
     @IBOutlet private weak var fileButton: UIButton!
-    
+
     @IBOutlet private weak var fileActivityIndicatorView: UIActivityIndicatorView!
-    
+
     @IBOutlet private weak var fileTopLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var fileLeftLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var fileRightLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var fileBottomLayoutConstraint: NSLayoutConstraint!
-    
+
     @IBOutlet private weak var fileMetaTopLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var fileMetaLeftLayoutConstraint: NSLayoutConstraint!
     @IBOutlet private weak var fileMetaRightLayoutConstraint: NSLayoutConstraint!
@@ -177,7 +177,12 @@ final class ParleyMessageView: UIView {
         ])
     }
 
-    func set(message: Message, forcedTime: Date?, mediaLoader: MediaLoaderProtocol?, shareManager: ShareManagerProtocol?) {
+    func set(
+        message: Message,
+        forcedTime: Date?,
+        mediaLoader: MediaLoaderProtocol?,
+        shareManager: ShareManagerProtocol?
+    ) {
         self.message = message
         time = forcedTime
         self.mediaLoader = mediaLoader
@@ -196,7 +201,7 @@ final class ParleyMessageView: UIView {
         renderMedia()
 
         renderButtons()
-        
+
         fixAppearanceForMessage()
     }
 
@@ -330,7 +335,7 @@ final class ParleyMessageView: UIView {
     private func renderMedia() {
         renderImageCorners()
         setImageWidth()
-        
+
         if let media = message.media {
             if media.getMediaType().isImageType {
                 hideFile()
@@ -344,12 +349,12 @@ final class ParleyMessageView: UIView {
             hideFile()
         }
     }
-    
+
     private func renderImage(_ media: MediaObject) {
         loadImage(media: media)
         displayImageLoading()
     }
-    
+
     private func renderFile(_ media: MediaObject) {
         for arrangedSubview in fileStackView.arrangedSubviews {
             fileStackView.removeArrangedSubview(arrangedSubview)
@@ -360,7 +365,7 @@ final class ParleyMessageView: UIView {
         }
         fileStackView.addArrangedSubview(fileContentView)
         fileStackView.addArrangedSubview(createSeparator())
-        
+
         fileLabel.text = media.displayFileName
         switch message.status {
         case .failed, .pending:
@@ -368,7 +373,7 @@ final class ParleyMessageView: UIView {
         case .success:
             fileButton.isHidden = false
         }
-        
+
         fileLabel.adjustsFontForContentSizeCategory = true
         fileButton.titleLabel?.adjustsFontForContentSizeCategory = true
         fileView.isHidden = false
@@ -405,12 +410,12 @@ final class ParleyMessageView: UIView {
         imageImageView.image = nil
         imageActivityIndicatorView.stopAnimating()
     }
-    
+
     private func hideFile() {
         for arrangedSubview in fileStackView.arrangedSubviews {
             fileStackView.removeArrangedSubview(arrangedSubview)
         }
-        
+
         fileView.isHidden = true
     }
 
@@ -436,13 +441,13 @@ final class ParleyMessageView: UIView {
                 // During cell reuse, the ongoing request could callback on another cell.
                 // This check prevents it from applying that image (or display it's failure).
                 guard imageRequestForMessageId == message.id else { return }
-                
+
                 // NOTE: Result should be of type image
                 guard let image = media.imageFromData(data) else {
                     displayFailedLoadingImage()
                     return
                 }
-                
+
                 display(image: image)
             } catch {
                 displayFailedLoadingImage()
@@ -463,24 +468,24 @@ final class ParleyMessageView: UIView {
         imageActivityIndicatorView.stopAnimating()
         renderGradients()
     }
-    
+
     private func displayFailedLoadingFileNoFileManager() {
         presentAlert(
-            title: ParleyLocalizationKey.messageFileLoadFailedNoFileManagerTitle.localized,
-            message: ParleyLocalizationKey.messageFileLoadFailedNoFileManagerMessage.localized
+            title: ParleyLocalizationKey.messageFileLoadFailedNoFileManagerTitle.localized(),
+            message: ParleyLocalizationKey.messageFileLoadFailedNoFileManagerMessage.localized()
         )
     }
-    
+
     private func displayFailedLoadingFile() {
         presentAlert(
-            title: ParleyLocalizationKey.messageFileLoadFailedSavingTitle.localized,
-            message: ParleyLocalizationKey.messageFileLoadFailedSavingMessage.localized
+            title: ParleyLocalizationKey.messageFileLoadFailedSavingTitle.localized(),
+            message: ParleyLocalizationKey.messageFileLoadFailedSavingMessage.localized()
         )
     }
-    
+
     private func presentAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let okMessage = ParleyLocalizationKey.ok.localized
+        let okMessage = ParleyLocalizationKey.ok.localized()
         alert.addAction(UIAlertAction(title: okMessage, style: .default))
         present(alert, animated: true)
     }
@@ -581,11 +586,15 @@ final class ParleyMessageView: UIView {
             let messageButtons = message.buttons
         {
             buttonsView.isHidden = false
-            if !message.hasFile && (message.title != nil || displayName == .message || message.message != nil || message.hasImage) {
+            if
+                !message
+                    .hasFile &&
+                    (message.title != nil || displayName == .message || message.message != nil || message.hasImage)
+            {
                 let sep = createSeparator()
                 buttonsStackView.addArrangedSubview(sep)
             }
-            
+
             for (tag, messageButton) in messageButtons.enumerated() {
                 let button = createButton(from: messageButton, tag: tag)
                 buttonsStackView.addArrangedSubview(button)
@@ -596,14 +605,14 @@ final class ParleyMessageView: UIView {
             buttonsView.isHidden = true
         }
     }
-    
+
     private func fixAppearanceForMessage() {
         if message.title != nil || displayName == .message || message.message != nil {
             fileTopLayoutConstraint.constant = appearance?.fileInsets?.top ?? 0
         } else {
             fileTopLayoutConstraint.constant = 0
         }
-        
+
         if message.hasFile && message.hasButtons {
             fileBottomLayoutConstraint.constant = 0
             buttonsTopLayoutConstraint.constant = 0
@@ -621,12 +630,24 @@ final class ParleyMessageView: UIView {
         separatorContainer.addSubview(separator)
         NSLayoutConstraint.activate([
             separator.heightAnchor.constraint(equalToConstant: 1),
-            separator.leadingAnchor.constraint(equalTo: separatorContainer.leadingAnchor, constant: appearance?.separatorInset?.left ?? 0),
-            separator.topAnchor.constraint(equalTo: separatorContainer.topAnchor, constant: appearance?.separatorInset?.top ?? 0),
-            separator.trailingAnchor.constraint(equalTo: separatorContainer.trailingAnchor, constant: -(appearance?.separatorInset?.right ?? 0)),
-            separator.bottomAnchor.constraint(equalTo: separatorContainer.bottomAnchor, constant: -(appearance?.separatorInset?.bottom ?? 0)),
+            separator.leadingAnchor.constraint(
+                equalTo: separatorContainer.leadingAnchor,
+                constant: appearance?.separatorInset?.left ?? 0
+            ),
+            separator.topAnchor.constraint(
+                equalTo: separatorContainer.topAnchor,
+                constant: appearance?.separatorInset?.top ?? 0
+            ),
+            separator.trailingAnchor.constraint(
+                equalTo: separatorContainer.trailingAnchor,
+                constant: -(appearance?.separatorInset?.right ?? 0)
+            ),
+            separator.bottomAnchor.constraint(
+                equalTo: separatorContainer.bottomAnchor,
+                constant: -(appearance?.separatorInset?.bottom ?? 0)
+            ),
         ])
-        
+
         return separatorContainer
     }
 
@@ -704,7 +725,7 @@ final class ParleyMessageView: UIView {
             .constant = (appearance.balloonContentTextInsets?.left ?? 0) + (appearance.metaInsets?.left ?? 0)
         imageMetaBottomLayoutConstraint
             .constant = (appearance.balloonContentTextInsets?.bottom ?? 0) + (appearance.metaInsets?.bottom ?? 0)
-        
+
         // Name
         nameLabel.textColor = appearance.nameColor
         nameLabel.font = appearance.nameFont
@@ -739,37 +760,39 @@ final class ParleyMessageView: UIView {
 
         // File
         fileIcon.tintColor = appearance.fileIconTintColor
-        
+
         fileLabel.textColor = appearance.fileNameColor
         fileLabel.font = appearance.fileNameFont
-        
+
         fileButton.setTitleColor(appearance.fileActionColor, for: .normal)
         fileButton.titleLabel?.font = appearance.fileActionFont
-        fileButton.setTitle(ParleyLocalizationKey.messageFileOpen.localized, for: .normal)
+        fileButton.setTitle(ParleyLocalizationKey.messageFileOpen.localized(), for: .normal)
         fileButton.addTarget(self, action: #selector(imageAction), for: .touchUpInside)
         if #available(iOS 15, *) {
             // NOTE: Needed to allow the font setting on the titleLabel to work after 15.0
             fileButton.configuration = nil
         }
-        
+
         fileActivityIndicatorView.color = appearance.fileActionColor
-        
+
         fileTopLayoutConstraint.constant = appearance.fileInsets?.top ?? 0
         fileLeftLayoutConstraint.constant = appearance.fileInsets?.left ?? 0
         fileRightLayoutConstraint.constant = appearance.fileInsets?.right ?? 0
         fileBottomLayoutConstraint.constant = appearance.fileInsets?.bottom ?? 0
-        
+
         fileMetaTopLayoutConstraint.constant = appearance.fileContentInsets?.top ?? 0
-        fileMetaLeftLayoutConstraint.constant = (appearance.balloonContentTextInsets?.left ?? 0) + (appearance.fileContentInsets?.left ?? 0)
-        fileMetaRightLayoutConstraint.constant = (appearance.balloonContentTextInsets?.right ?? 0) + (appearance.fileContentInsets?.right ?? 0)
+        fileMetaLeftLayoutConstraint
+            .constant = (appearance.balloonContentTextInsets?.left ?? 0) + (appearance.fileContentInsets?.left ?? 0)
+        fileMetaRightLayoutConstraint
+            .constant = (appearance.balloonContentTextInsets?.right ?? 0) + (appearance.fileContentInsets?.right ?? 0)
         fileMetaBottomLayoutConstraint.constant = appearance.fileContentInsets?.bottom ?? 0
-        
+
         // Buttons
         buttonsTopLayoutConstraint.constant = appearance.buttonsInsets?.top ?? 0
         buttonsLeftLayoutConstraint.constant = appearance.buttonsInsets?.left ?? 0
         buttonsRightLayoutConstraint.constant = appearance.buttonsInsets?.right ?? 0
         buttonsBottomLayoutConstraint.constant = appearance.buttonsInsets?.bottom ?? 0
-        
+
         // Meta
         timeLabel.textColor = appearance.timeColor
         timeLabel.font = appearance.timeFont
@@ -793,10 +816,10 @@ final class ParleyMessageView: UIView {
         guard let media = message.media else {
             return
         }
-        
+
         delegate?.didSelectMedia(media)
     }
-    
+
     @IBAction
     private func openMediaAction(sender: UIButton) {
         fileButton.isHidden = true
@@ -806,19 +829,20 @@ final class ParleyMessageView: UIView {
                 fileButton.isHidden = false
                 fileActivityIndicatorView.stopAnimating()
             }
-            
-            
+
             guard let shareManager else {
                 displayFailedLoadingFileNoFileManager()
                 return
             }
-            
-            guard let media = message.media,
-                  let url = try? await shareManager.share(media: media) else {
+
+            guard
+                let media = message.media,
+                let url = try? await shareManager.share(media: media) else
+            {
                 displayFailedLoadingFile()
                 return
             }
-            
+
             delegate?.shareMedia(url: url)
         }
     }

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
@@ -587,9 +587,8 @@ final class ParleyMessageView: UIView {
         {
             buttonsView.isHidden = false
             if
-                !message
-                    .hasFile &&
-                    (message.title != nil || displayName == .message || message.message != nil || message.hasImage)
+                !message.hasFile &&
+                (message.title != nil || displayName == .message || message.message != nil || message.hasImage)
             {
                 let sep = createSeparator()
                 buttonsStackView.addArrangedSubview(sep)

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewAppearance.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewAppearance.swift
@@ -45,16 +45,16 @@ public class ParleyMessageViewAppearance {
     }()
 
     public var messageInsets: UIEdgeInsets?
-    
+
     // File
     public var fileIconTintColor = UIColor(red: 0.29, green: 0.37, blue: 0.51, alpha: 1.0)
-    
-    public var fileNameColor =  UIColor(white: 0, alpha: 1)
+
+    public var fileNameColor = UIColor(white: 0, alpha: 1)
     @ParleyScaledFont(textStyle: .body) public var fileNameFont = .systemFont(ofSize: 13)
-    
+
     public var fileActionColor = UIColor(red: 0.29, green: 0.37, blue: 0.51, alpha: 1.0)
     @ParleyScaledFont(textStyle: .headline) public var fileActionFont = .boldSystemFont(ofSize: 16)
-    
+
     public var fileInsets: UIEdgeInsets? = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
     public var fileContentInsets: UIEdgeInsets? = UIEdgeInsets(top: 14, left: 0, bottom: 14, right: 0)
 
@@ -65,7 +65,7 @@ public class ParleyMessageViewAppearance {
     @ParleyScaledFont(textStyle: .callout) public var timeFont = .systemFont(ofSize: 12)
 
     public var statusTintColor = UIColor(white: 1, alpha: 0.6)
-    
+
     // Buttons
     public var buttonsInsets: UIEdgeInsets?
     public var buttonInsets: UIEdgeInsets?
@@ -76,7 +76,7 @@ public class ParleyMessageViewAppearance {
     public var buttonColor = UIColor(red: 0.29, green: 0.37, blue: 0.51, alpha: 1.0)
 
     public var separatorInset: UIEdgeInsets?
-    
+
     init() {
         imagePlaceholder = UIImage(named: "placeholder", in: .module, compatibleWith: nil)!
     }

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -22,13 +22,13 @@ public class ParleyView: UIView {
     private weak var notificationsConstraintBottom: NSLayoutConstraint?
     @IBOutlet weak var pushDisabledNotificationView: ParleyNotificationView! {
         didSet {
-            pushDisabledNotificationView.text = ParleyLocalizationKey.pushDisabled.localized
+            pushDisabledNotificationView.text = ParleyLocalizationKey.pushDisabled.localized()
         }
     }
 
     @IBOutlet weak var offlineNotificationView: ParleyNotificationView! {
         didSet {
-            offlineNotificationView.text = ParleyLocalizationKey.notificationOffline.localized
+            offlineNotificationView.text = ParleyLocalizationKey.notificationOffline.localized()
         }
     }
 
@@ -46,7 +46,7 @@ public class ParleyView: UIView {
 
     @IBOutlet weak var composeView: ParleyComposeView! {
         didSet {
-            composeView.placeholder = ParleyLocalizationKey.typeMessage.localized
+            composeView.placeholder = ParleyLocalizationKey.typeMessage.localized()
             composeView.maxCount = kParleyMessageMaxCount
 
             composeView.delegate = self
@@ -88,7 +88,7 @@ public class ParleyView: UIView {
             mediaEnabled = imagesEnabled
         }
     }
-    
+
     public var mediaEnabled = true {
         didSet {
             composeView.allowMediaUpload = mediaEnabled
@@ -126,12 +126,12 @@ public class ParleyView: UIView {
     deinit {
         removeObservers()
     }
-    
+
     private lazy var shareManager: ShareManager? = {
         guard let shareManager = try? ShareManager(mediaLoader: parley.mediaLoader) else {
             return nil
         }
-        
+
         return shareManager
     }()
 
@@ -525,7 +525,7 @@ extension ParleyView: ParleyDelegate {
             composeView.isHidden = true
             suggestionsView.isHidden = true
 
-            statusLabel.text = ParleyLocalizationKey.stateUnconfigured.localized
+            statusLabel.text = ParleyLocalizationKey.stateUnconfigured.localized()
             statusLabel.isHidden = false
 
             activityIndicatorView.isHidden = true
@@ -547,7 +547,7 @@ extension ParleyView: ParleyDelegate {
             composeView.isHidden = true
             suggestionsView.isHidden = true
 
-            statusLabel.text = ParleyLocalizationKey.stateFailed.localized
+            statusLabel.text = ParleyLocalizationKey.stateFailed.localized()
             statusLabel.isHidden = false
 
             activityIndicatorView.isHidden = true
@@ -763,15 +763,15 @@ extension ParleyView: UITableViewDelegate {
 extension ParleyView: ParleyComposeViewDelegate {
 
     func failedToSelectImage() {
-        let title = ParleyLocalizationKey.sendFailedTitle.localized
-        let message = ParleyLocalizationKey.sendFailedBodySelectingImage.localized
+        let title = ParleyLocalizationKey.sendFailedTitle.localized()
+        let message = ParleyLocalizationKey.sendFailedBodySelectingImage.localized()
         presentInformationalAlert(title: title, message: message)
     }
 
     @MainActor
     private func presentInformationalAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let okMessage = ParleyLocalizationKey.ok.localized
+        let okMessage = ParleyLocalizationKey.ok.localized()
         alert.addAction(UIAlertAction(title: okMessage, style: .default))
         present(alert, animated: true)
     }
@@ -793,8 +793,8 @@ extension ParleyView: ParleyComposeViewDelegate {
             }
 
             guard !mediaModel.isLargerThan(size: Self.maximumImageSizeInMegabytes) else {
-                let title = ParleyLocalizationKey.sendFailedTitle.localized
-                let message = ParleyLocalizationKey.sendFailedBodyMediaTooLarge.localized
+                let title = ParleyLocalizationKey.sendFailedTitle.localized()
+                let message = ParleyLocalizationKey.sendFailedBodyMediaTooLarge.localized()
                 presentInformationalAlert(title: title, message: message)
                 return
             }
@@ -813,14 +813,14 @@ extension ParleyView: ParleyComposeViewDelegate {
             await send(media: mediaModel)
         }
     }
-    
+
     func send(file url: URL) {
         Task { @MainActor in
             guard let fileData = FileManager.default.contents(atPath: url.path) else {
                 presentInvalidMediaAlert()
                 return
             }
-            
+
             let mediaModel = MediaModel(data: fileData, url: url)
             await send(media: mediaModel)
         }
@@ -837,15 +837,15 @@ extension ParleyView: ParleyComposeViewDelegate {
 
     @MainActor
     private func presentInvalidMediaAlert() {
-        let title = ParleyLocalizationKey.sendFailedTitle.localized
-        let message = ParleyLocalizationKey.sendFailedBodyMediaInvalid.localized
+        let title = ParleyLocalizationKey.sendFailedTitle.localized()
+        let message = ParleyLocalizationKey.sendFailedBodyMediaInvalid.localized()
         presentInformationalAlert(title: title, message: message)
     }
 
     @MainActor
     private func presentImageToLargeAlert() {
-        let title = ParleyLocalizationKey.sendFailedTitle.localized
-        let message = ParleyLocalizationKey.sendFailedBodyMediaTooLarge.localized
+        let title = ParleyLocalizationKey.sendFailedTitle.localized()
+        let message = ParleyLocalizationKey.sendFailedBodyMediaTooLarge.localized()
         presentInformationalAlert(title: title, message: message)
     }
 }
@@ -857,18 +857,18 @@ extension ParleyView: MessageTableViewCellDelegate {
         guard media.getMediaType().isImageType else {
             return
         }
-        
+
         let imageViewController = MessageImageViewController(
             messageMedia: media,
             mediaLoader: parley.mediaLoader
         )
-        
+
         imageViewController.modalPresentationStyle = .overFullScreen
         imageViewController.modalTransitionStyle = .crossDissolve
-        
+
         present(imageViewController, animated: true, completion: nil)
     }
-    
+
     func shareMedia(url: URL) {
         print(url)
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)

--- a/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCell.swift
+++ b/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCell.swift
@@ -46,7 +46,12 @@ final class MessageTableViewCell: UITableViewCell {
         if message.hasMedium || message.title != nil || message.message != nil || message.hasButtons {
             messageView.isHidden = false
 
-            parleyMessageView.set(message: message, forcedTime: nil, mediaLoader: mediaLoader, shareManager: shareManager)
+            parleyMessageView.set(
+                message: message,
+                forcedTime: nil,
+                mediaLoader: mediaLoader,
+                shareManager: shareManager
+            )
         } else {
             messageView.isHidden = true
         }

--- a/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCellAppearance.swift
+++ b/Sources/Parley/Views/TableViewCells/MessageTableViewCell/MessageTableViewCellAppearance.swift
@@ -46,8 +46,8 @@ public class MessageTableViewCellAppearance: ParleyMessageViewAppearance {
         appearance.balloonContentTextInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
 
         appearance.messageTextViewAppearance.textColor = UIColor.white
-        appearance.messageTextViewAppearance.linkTintColor =  UIColor(white: 1, alpha: 0.6)
-        
+        appearance.messageTextViewAppearance.linkTintColor = UIColor(white: 1, alpha: 0.6)
+
         appearance.fileIconTintColor = UIColor(red: 0.6, green: 0.81, blue: 1, alpha: 1.0)
         appearance.fileNameColor = UIColor.white
         appearance.fileActionColor = UIColor(red: 0.6, green: 0.81, blue: 1, alpha: 1.0)

--- a/Tests/ParleyTests/Data/Remotes/ParleyRemoteTests.swift
+++ b/Tests/ParleyTests/Data/Remotes/ParleyRemoteTests.swift
@@ -341,10 +341,10 @@ final class ParleyRemoteTests: XCTestCase {
 
         sut.execute(
             path: "media",
-            imageData: Data(),
+            data: Data(),
             name: "image",
             fileName: "image.jpg",
-            imageType: .jpg,
+            type: .imageJPeg,
             result: { (value: Result<[MediaResponse], Error>) in
                 resultCalled = true
                 switch value {

--- a/Tests/ParleyTests/ParleyMessageViewTests.swift
+++ b/Tests/ParleyTests/ParleyMessageViewTests.swift
@@ -152,7 +152,7 @@ final class ParleyMessageViewTests: XCTestCase {
 
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoader.loadResult = data
 
         let sut = ParleyMessageView()
@@ -183,7 +183,7 @@ final class ParleyMessageViewTests: XCTestCase {
 
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoader.loadResult = data
 
         let sut = ParleyMessageView()
@@ -244,14 +244,18 @@ final class ParleyMessageViewTests: XCTestCase {
 
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoader.loadResult = data
 
         let sut = ParleyMessageView()
 
         sut.apply(MessageCollectionViewCellAppearance.agent())
         sut.set(
-            message: .makeTestData(title: nil, message: nil, media: MediaObject(id: "identifier", mimeType: "image/png")),
+            message: .makeTestData(
+                title: nil,
+                message: nil,
+                media: MediaObject(id: "identifier", mimeType: "image/png")
+            ),
             forcedTime: Self.dummyDate,
             mediaLoader: mediaLoader,
             shareManager: nil
@@ -270,14 +274,18 @@ final class ParleyMessageViewTests: XCTestCase {
 
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoader.loadResult = data
 
         let sut = ParleyMessageView()
 
         sut.apply(MessageCollectionViewCellAppearance.agent())
         sut.set(
-            message: .makeTestData(title: nil, message: nil, media: MediaObject(id: "identifier", mimeType: "image/png")),
+            message: .makeTestData(
+                title: nil,
+                message: nil,
+                media: MediaObject(id: "identifier", mimeType: "image/png")
+            ),
             forcedTime: Self.dummyDate,
             mediaLoader: mediaLoader,
             shareManager: nil
@@ -300,7 +308,11 @@ final class ParleyMessageViewTests: XCTestCase {
 
         sut.apply(MessageCollectionViewCellAppearance.agent())
         sut.set(
-            message: .makeTestData(title: nil, message: nil, media: MediaObject(id: "identifier", mimeType: "image/png")),
+            message: .makeTestData(
+                title: nil,
+                message: nil,
+                media: MediaObject(id: "identifier", mimeType: "image/png")
+            ),
             forcedTime: Self.dummyDate,
             mediaLoader: mediaLoader,
             shareManager: nil
@@ -321,7 +333,7 @@ final class ParleyMessageViewTests: XCTestCase {
 
         let image = try XCTUnwrap(UIImage(named: "white_image", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoader.loadResult = data
 
         let sut = ParleyMessageView()

--- a/Tests/ParleyTests/ParleyTests.swift
+++ b/Tests/ParleyTests/ParleyTests.swift
@@ -19,13 +19,13 @@ final class ParleyTests: XCTestCase {
     func testSetLocalizationManager() {
         let localizationKeyReturnValue = "test!"
 
-        XCTAssertNotEqual(ParleyLocalizationKey.cancel.localized, ParleyLocalizationKey.cancel.rawValue)
-        XCTAssertEqual(localizationManagerSpy.getLocalizationKeyCallsCount, 0)
+        XCTAssertNotEqual(ParleyLocalizationKey.cancel.localized(), ParleyLocalizationKey.cancel.rawValue)
+        XCTAssertEqual(localizationManagerSpy.getLocalizationKeyArgumentsCallsCount, 0)
 
         Parley.setLocalizationManager(localizationManagerSpy)
-        localizationManagerSpy.getLocalizationKeyReturnValue = localizationKeyReturnValue
+        localizationManagerSpy.getLocalizationKeyArgumentsReturnValue = localizationKeyReturnValue
 
-        XCTAssertEqual(ParleyLocalizationKey.cancel.localized, localizationKeyReturnValue)
-        XCTAssertEqual(localizationManagerSpy.getLocalizationKeyCallsCount, 1)
+        XCTAssertEqual(ParleyLocalizationKey.cancel.localized(), localizationKeyReturnValue)
+        XCTAssertEqual(localizationManagerSpy.getLocalizationKeyArgumentsCallsCount, 1)
     }
 }

--- a/Tests/ParleyTests/ParleyViewTests.swift
+++ b/Tests/ParleyTests/ParleyViewTests.swift
@@ -120,7 +120,7 @@ final class ParleyViewTests: XCTestCase {
         let mediaLoaderStub = MediaLoaderStub()
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoaderStub.loadResult = data
 
         let sut = ParleyView(
@@ -182,7 +182,7 @@ final class ParleyViewTests: XCTestCase {
         let mediaLoaderStub = MediaLoaderStub()
         let image = try XCTUnwrap(UIImage(named: "Parley", in: .module, compatibleWith: nil))
         let data = try XCTUnwrap(image.pngData())
-        
+
         mediaLoaderStub.loadResult = data
 
         let sut = ParleyView(

--- a/Tests/ParleyTests/TestDoubles/LocalizationManagerSpy.swift
+++ b/Tests/ParleyTests/TestDoubles/LocalizationManagerSpy.swift
@@ -4,31 +4,31 @@ import XCTest
 public final class LocalizationManagerSpy: LocalizationManager {
 
     public init(
-        getLocalizationKeyReturnValue: String? = nil
+        getLocalizationKeyArgumentsReturnValue: String? = nil
     ) {
-        self.getLocalizationKeyReturnValue = getLocalizationKeyReturnValue
+        self.getLocalizationKeyArgumentsReturnValue = getLocalizationKeyArgumentsReturnValue
     }
 
     // MARK: - getLocalization
 
-    public var getLocalizationKeyCallsCount = 0
-    public var getLocalizationKeyCalled: Bool {
-        getLocalizationKeyCallsCount > 0
+    public var getLocalizationKeyArgumentsCallsCount = 0
+    public var getLocalizationKeyArgumentsCalled: Bool {
+        getLocalizationKeyArgumentsCallsCount > 0
     }
 
-    public var getLocalizationKeyReceivedKey: ParleyLocalizationKey?
-    public var getLocalizationKeyReceivedInvocations: [ParleyLocalizationKey] = []
-    public var getLocalizationKeyReturnValue: String!
-    public var getLocalizationKeyClosure: ((ParleyLocalizationKey) -> String)?
+    public var getLocalizationKeyArgumentsReceivedArguments: (key: ParleyLocalizationKey, arguments: CVarArg)?
+    public var getLocalizationKeyArgumentsReceivedInvocations: [(key: ParleyLocalizationKey, arguments: CVarArg)] = []
+    public var getLocalizationKeyArgumentsReturnValue: String!
+    public var getLocalizationKeyArgumentsClosure: ((ParleyLocalizationKey, CVarArg) -> String)?
 
-    public func getLocalization(key: ParleyLocalizationKey) -> String {
-        getLocalizationKeyCallsCount += 1
-        getLocalizationKeyReceivedKey = key
-        getLocalizationKeyReceivedInvocations.append(key)
-        if let getLocalizationKeyClosure {
-            return getLocalizationKeyClosure(key)
+    public func getLocalization(key: ParleyLocalizationKey, arguments: CVarArg...) -> String {
+        getLocalizationKeyArgumentsCallsCount += 1
+        getLocalizationKeyArgumentsReceivedArguments = (key: key, arguments: arguments)
+        getLocalizationKeyArgumentsReceivedInvocations.append((key: key, arguments: arguments))
+        if let getLocalizationKeyArgumentsClosure {
+            return getLocalizationKeyArgumentsClosure(key, arguments)
         } else {
-            return getLocalizationKeyReturnValue
+            return getLocalizationKeyArgumentsReturnValue
         }
     }
 

--- a/Tests/ParleyTests/TestDoubles/MediaLoaderStub.swift
+++ b/Tests/ParleyTests/TestDoubles/MediaLoaderStub.swift
@@ -2,11 +2,11 @@ import Foundation
 @testable import Parley
 
 final class MediaLoaderStub: MediaLoaderProtocol {
-    
+
     var loadResult: Data?
     var url: URL?
     var error: MediaLoader.MediaLoaderError = .deinitialized
-    
+
     func load(media: MediaObject) async throws -> Data {
         if let loadResult {
             return loadResult
@@ -14,7 +14,7 @@ final class MediaLoaderStub: MediaLoaderProtocol {
             throw error
         }
     }
-    
+
     func reset() async {
     }
 }

--- a/Tests/ParleyTests/TestDoubles/ShareManagerStub.swift
+++ b/Tests/ParleyTests/TestDoubles/ShareManagerStub.swift
@@ -2,10 +2,10 @@ import Foundation
 @testable import Parley
 
 final class ShareManagerStub: ShareManagerProtocol {
-    
+
     var url: URL?
     var error: ShareManager.ShareManagerError = .unableToSaveFile(id: "Test")
-    
+
     func share(media: MediaObject) async throws -> URL {
         if let url {
             return url


### PR DESCRIPTION
When there is a localization key with arguments the `ParleyLocalizationManager` is not used, but `.localizedStringWithFormat` instead. This will move that also to the `ParleyLocalizationManager`.