### PR TITLE
Feature/fix file action font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.2 - Released 17 Oct 2024
+
+- Fixed `fileActionFont` not updating on initial load.
+- Styling: Added `ParleyMessageViewAppearance.fileIcon` to configure the icon for files.
+
 ## 4.2.1 - Released 10 Oct 2024
 
 - Fixed `LocalizationManager` not localizing keys that had arguments.

--- a/Example/ParleyExample.xcodeproj/project.pbxproj
+++ b/Example/ParleyExample.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.2.1;
+				MARKETING_VERSION = 4.2.2;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"DEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = nu.parley;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.2.1;
+				MARKETING_VERSION = 4.2.2;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"RELEASE\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.webuildapps.tracebuzz.parleydemo;
@@ -579,7 +579,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.2.1;
+				MARKETING_VERSION = 4.2.2;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"ALPHA\"";
 				PRODUCT_BUNDLE_IDENTIFIER = nu.parley;

--- a/Example/ParleyExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ParleyExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2bbb1082def8ae62ff962596af7834efb938b98982a7f6ddcb186f1bef079eb0",
+  "originHash" : "56118e514ee3bf7bdb296112ddc3b98ab50d0f4634d0105daff3e9834765ead4",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
-        "version" : "5.9.1"
+        "revision" : "ea6a94b7dddffd0ca4d0f29252d95310b84dec84",
+        "version" : "5.10.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ashleymills/Reachability.swift.git",
       "state" : {
-        "revision" : "7b7018a69c84ea94ac2a38dff626e16ea81d1db9",
-        "version" : "5.2.1"
+        "revision" : "21d1dc412cfecbe6e34f1f4c4eb88d3f912654a6",
+        "version" : "5.2.4"
       }
     },
     {

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.xib
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.xib
@@ -251,18 +251,18 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <view contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="740" translatesAutoresizingMaskIntoConstraints="NO" id="iEv-L2-Mz5">
-                                                                    <rect key="frame" x="252" y="18.5" width="162" height="34.5"/>
+                                                                    <rect key="frame" x="252" y="20.5" width="162" height="30"/>
                                                                     <subviews>
                                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kz2-lo-cCt">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="162" height="34.5"/>
-                                                                            <state key="normal" title="Button"/>
-                                                                            <buttonConfiguration key="configuration" style="plain" title="message.file.open"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="162" height="30"/>
+                                                                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                                            <state key="normal" title="message.file.open"/>
                                                                             <connections>
                                                                                 <action selector="openMediaActionWithSender:" destination="-1" eventType="touchUpInside" id="jfq-g2-gFu"/>
                                                                             </connections>
                                                                         </button>
                                                                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="cDB-2u-kSP">
-                                                                            <rect key="frame" x="71" y="0.0" width="20" height="34.5"/>
+                                                                            <rect key="frame" x="71" y="0.0" width="20" height="30"/>
                                                                         </activityIndicatorView>
                                                                     </subviews>
                                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Changed button type to default to prevent `Plain` from overriding the initial font.

<img width="270" alt="image" src="https://github.com/user-attachments/assets/8a21bc83-f2c1-4d6f-b0c9-8e2d5c6f1f03">
