### PR TITLE
Implement sendable on network so it is used safly on swift 6;

### DIFF
--- a/Sources/Parley/Config/ApiVersion.swift
+++ b/Sources/Parley/Config/ApiVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ApiVersion {
+public enum ApiVersion: Sendable {
     case v1_6
     case v1_7
 }

--- a/Sources/Parley/Config/ParleyNetworkConfig.swift
+++ b/Sources/Parley/Config/ParleyNetworkConfig.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public struct ParleyNetworkConfig {
+public struct ParleyNetworkConfig: Sendable {
     public let url: String
     package let path: String
     package let headers: [String: String]

--- a/Sources/Parley/Data/Localization/LocalizationManager.swift
+++ b/Sources/Parley/Data/Localization/LocalizationManager.swift
@@ -1,3 +1,3 @@
-public protocol LocalizationManager {
+public protocol LocalizationManager: Sendable {
     func getLocalization(key: ParleyLocalizationKey, arguments: CVarArg...) -> String
 }

--- a/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
+++ b/Sources/Parley/Data/Localization/ParleyLocalizationKey.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ParleyLocalizationKey: String {
+public enum ParleyLocalizationKey: String, Sendable {
     case cancel = "parley_cancel"
     case ok = "parley_ok"
     case stateFailed = "parley_state_failed"

--- a/Sources/Parley/Data/Models/Common/ParleyHTTPDataResponse.swift
+++ b/Sources/Parley/Data/Models/Common/ParleyHTTPDataResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ParleyHTTPDataResponse: ResponseValidator {
+public struct ParleyHTTPDataResponse: ResponseValidator, Sendable {
 
     public let statusCode: Int
     public let headers: [String: String]

--- a/Sources/Parley/Data/Models/Common/ParleyHTTPErrorResponse.swift
+++ b/Sources/Parley/Data/Models/Common/ParleyHTTPErrorResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ParleyHTTPErrorResponse: Error {
+public struct ParleyHTTPErrorResponse: Error, Sendable {
     public let statusCode: Int?
     public let headers: [String: String]?
     public let data: Data?

--- a/Sources/Parley/Data/Models/Common/ParleyHTTPRequestMethod.swift
+++ b/Sources/Parley/Data/Models/Common/ParleyHTTPRequestMethod.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents an HTTP request method.
-public enum ParleyHTTPRequestMethod: String, Codable {
+public enum ParleyHTTPRequestMethod: String, Codable, Sendable {
     case get = "GET"
     case head = "HEAD"
     case post = "POST"

--- a/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
+++ b/Sources/Parley/Data/Remotes/ParleyNetworkSession.swift
@@ -17,14 +17,14 @@ import UIKit
 ///    networkSession: YourImplementationOfParleyNetworkSession(),
 /// )
 /// ```
-public protocol ParleyNetworkSession {
+public protocol ParleyNetworkSession: Sendable {
 
     func request(
         _ url: URL,
         data: Data?,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
-        completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
+        completion: @Sendable @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
     )
 
     func upload(
@@ -32,6 +32,6 @@ public protocol ParleyNetworkSession {
         to url: URL,
         method: ParleyHTTPRequestMethod,
         headers: [String: String],
-        completion: @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
+        completion: @Sendable @escaping (_ result: Result<ParleyHTTPDataResponse, ParleyHTTPErrorResponse>) -> Void
     )
 }


### PR DESCRIPTION
Add the `Sendable` protocol on enum/structs that are needed when library is called from swift 6;