### PR TITLE
Fixed a crash when trying to open/share a PDF document on iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.4.6 - Released 29 Oct 2025
+
+- [Chat] iPad app now correctly shows the share sheet with a popover pointing to the cell the open button was clicked on.
+- [Source] Switched from using deprecated `UIApplication.shared.windows` to the scene-based API's.
+
 ## 4.4.5 - Released 9 Oct 2025
 
 - [Chat] Fixed cases where reopening the chat does not show newly received messages. 

--- a/Example/ParleyExample.xcodeproj/project.pbxproj
+++ b/Example/ParleyExample.xcodeproj/project.pbxproj
@@ -497,7 +497,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.4.5;
+				MARKETING_VERSION = 4.4.6;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"DEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = nu.parley;
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.4.5;
+				MARKETING_VERSION = 4.4.6;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"RELEASE\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.webuildapps.tracebuzz.parleydemo;
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.4.5;
+				MARKETING_VERSION = 4.4.6;
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"ALPHA\"";
 				PRODUCT_BUNDLE_IDENTIFIER = nu.parley;

--- a/Example/ParleyExample/Supporting Files/Info.plist
+++ b/Example/ParleyExample/Supporting Files/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2253</string>
+	<string>2254</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Example/ParleyExample/Supporting Files/Info.plist
+++ b/Example/ParleyExample/Supporting Files/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2252</string>
+	<string>2253</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Sources/Parley/Config/Constants.swift
+++ b/Sources/Parley/Config/Constants.swift
@@ -1,4 +1,4 @@
-let kParleyVersion = "4.4.2"
+let kParleyVersion = "4.4.6"
 
 let kParleyMessageMaxCount = 5000
 

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageView.swift
@@ -889,8 +889,13 @@ final class ParleyMessageView: UIView {
                 displayFailedLoadingFile()
                 return
             }
-
-            delegate?.shareMedia(url: url)
+            
+            if let vc = parentViewController ?? activeSceneRootViewController {
+                let sourceRect = convert(self.bounds, to: vc.view)
+                delegate?.shareMedia(url: url, source: sourceRect)
+            } else {
+                delegate?.shareMedia(url: url, source: self.bounds)
+            }
         }
     }
 

--- a/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewDelegate.swift
+++ b/Sources/Parley/Views/ParleyMessageView/ParleyMessageViewDelegate.swift
@@ -1,7 +1,8 @@
 import Foundation
+import UIKit
 
 protocol ParleyMessageViewDelegate: AnyObject {
     @MainActor func didSelectMedia(_ media: MediaObject)
-    @MainActor func shareMedia(url: URL)
+    @MainActor func shareMedia(url: URL, source: CGRect)
     @MainActor func didSelect(_ button: MessageButton)
 }

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -891,8 +891,15 @@ extension ParleyView: MessageTableViewCellDelegate {
         present(imageViewController, animated: true, completion: nil)
     }
 
-    func shareMedia(url: URL) {
+    func shareMedia(url: URL, source: CGRect) {
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        
+        if let popoverController = activityViewController.popoverPresentationController {
+            popoverController.sourceView = self
+            popoverController.sourceRect = source
+            popoverController.permittedArrowDirections = .any
+        }
+
         present(activityViewController, animated: true, completion: nil)
     }
 

--- a/Sources/Parley/Views/ParleyView.swift
+++ b/Sources/Parley/Views/ParleyView.swift
@@ -894,10 +894,12 @@ extension ParleyView: MessageTableViewCellDelegate {
     func shareMedia(url: URL, source: CGRect) {
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         
-        if let popoverController = activityViewController.popoverPresentationController {
-            popoverController.sourceView = self
-            popoverController.sourceRect = source
-            popoverController.permittedArrowDirections = .any
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            if let popoverController = activityViewController.popoverPresentationController {
+                popoverController.sourceView = self
+                popoverController.sourceRect = source
+                popoverController.permittedArrowDirections = .any
+            }
         }
 
         present(activityViewController, animated: true, completion: nil)


### PR DESCRIPTION
- iPad app now correctly shows the share sheet with a popover pointing to the cell the open button was clicked on.
- Switched from using deprecated `UIApplication.shared.windows` to the scene-based API's.