### PR TITLE
Feat: make downloading images work again;

### DIFF
--- a/Sources/Parley/Data/Repositories/MediaRepository.swift
+++ b/Sources/Parley/Data/Repositories/MediaRepository.swift
@@ -70,7 +70,11 @@ extension MediaRepository {
     }
 
     private func getRemoteFetchPath(url: URL) -> String {
-        url.pathComponents.dropFirst().dropFirst().joined(separator: "/")
+        guard url.pathComponents.count > 1 else {
+            return url.absoluteString
+        }
+
+        return url.pathComponents.dropFirst().dropFirst().joined(separator: "/")
     }
 
     private func move(_ local: ParleyStoredMedia, to remoteId: String) async {

--- a/Sources/Parley/Extensions/NSItemProviderExtensions.swift
+++ b/Sources/Parley/Extensions/NSItemProviderExtensions.swift
@@ -1,7 +1,7 @@
 import UIKit
 import UniformTypeIdentifiers
 
-extension NSItemProvider {
+extension NSItemProvider: @unchecked @retroactive Sendable {
 
     enum NSItemProviderLoadImageError: Error {
         case unexpectedImageType
@@ -10,7 +10,7 @@ extension NSItemProvider {
     }
 
     @available(iOS 14.0, *)
-    struct LoadedImage {
+    struct LoadedImage: Sendable {
         let image: UIImage
         let data: Data
         let type: UTType


### PR DESCRIPTION
When uploading a image against api endpoint 1.8 or 1.9 downloading will not work. This is caused by the stripping of the path in `Sources/Parley/Data/Repositories/MediaRepository.swift`.